### PR TITLE
Update IRF.combine_lookup_table_parts.sh

### DIFF
--- a/scripts/VTS/IRF.combine_lookup_table_parts.sh
+++ b/scripts/VTS/IRF.combine_lookup_table_parts.sh
@@ -37,7 +37,7 @@ bash $(dirname "$0")"/helper_scripts/UTILITY.script_init.sh"
 
 # EventDisplay version
 EDVERSION=`$EVNDISPSYS/bin/combineLookupTables --version | tr -d .| sed -e 's/[a-Z]*$//'`
-EDVERSION=`$EVNDISPSYS/bin/combineLookupTables --version | tr -d .`
+#EDVERSION=`$EVNDISPSYS/bin/combineLookupTables --version | tr -d .`
 
 # Parse command line arguments
 OFILE=$1


### PR DESCRIPTION
My first contribution to ED.

"EDVERSION" variable was containing 'v480g' instead of 'v480', as the rest of the IRF scripts.

I assume that line should be commented.

Science, you are welcome.