### PR TITLE
Telescope-dependent MC size scaling to attempt to correct the energy …

### DIFF
--- a/README/README.MSCW_ENERGY
+++ b/README/README.MSCW_ENERGY
@@ -76,6 +76,12 @@ Additional options for table filling:
 	 -mindistancetocameracenter=FLOAT  minimum distance of events from camera center (MC distance, default = -1.e10)
 	 -maxdistancetocameracenter=FLOAT  maximum distance of events from camera center (MC distance, default =  1.e10)
 	 -minImages=INT          minimum number of images required per event (comparator geq, default=2)
+         (general corrections, optional)
+         -sizecorrect=FLOAT,FLOAT,FLOAT,...      apply correction to the size in the mscw/mscl/energy table [experimental]
+         (individual corrections, optional, overwrites general corrections)
+         -sizemscwcorrect=FLOAT,FLOAT,FLOAT,...  apply correction to the size in the mscw table, per telescope  [experimental]
+         -sizemsclcorrect=FLOAT,FLOAT,FLOAT,...  apply correction to the size in the mscl table     [experimental]
+         -sizeenergycorrect=FLOAT,FLOAT,FLOAT,...  apply correction to the size in the energy table [experimental]
 
 Additional options for table reading:
 

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -483,13 +483,23 @@ class VTableLookupDataHandler
 		{
 			return fOutFile;
 		}
-		double* getSize( double iSizeCorrection = 1., bool iSelectedImagesOnly = false, bool iSize2 = false );
-		double* getSize( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly, bool iSize2 = false );
-		double* getSize2( double iSizeCorrection = 1., bool iSelectedImagesOnly = false )
+		double* getSize( double iSizeCorrection = 1., bool iSelectedImagesOnly = false, bool iSize2 = false );        // deprecated
+		double* getSize( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly, bool iSize2 = false ); // deprecated
+		double* getSize( vector<double> iSizeCorrection, bool iSelectedImagesOnly = false, bool iSize2 = false );
+		double* getSize( vector<double> iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly = false, bool iSize2 = false );
+		double* getSize2( double iSizeCorrection = 1., bool iSelectedImagesOnly = false ) // deprecated
 		{
 			return getSize( iSizeCorrection, iSelectedImagesOnly, true );
 		}
-		double* getSize2( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly )
+		double* getSize2( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly ) // deprecated
+		{
+			return getSize( iSizeCorrection, iTelType, iSelectedImagesOnly, true );
+		}
+		double* getSize2( vector<double> iSizeCorrection, bool iSelectedImagesOnly )
+		{
+			return getSize( iSizeCorrection, iSelectedImagesOnly, true );
+		}
+		double* getSize2( vector<double> iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly )
 		{
 			return getSize( iSizeCorrection, iTelType, iSelectedImagesOnly, true );
 		}

--- a/inc/VTableLookupRunParameter.h
+++ b/inc/VTableLookupRunParameter.h
@@ -51,9 +51,9 @@ class VTableLookupRunParameter : public TNamed, public VGlobalRunParameter
 		
 		bool  fUseSelectedImagesOnly;
 		
-		double fMSCWSizecorrection;
-		double fMSCLSizecorrection;
-		double fEnergySizecorrection;
+		vector<double> fMSCWSizecorrection;
+		vector<double> fMSCLSizecorrection;
+		vector<double> fEnergySizecorrection;
 		string writeoption;
 		bool bNoNoTrigger;
 		int  bWriteReconstructedEventsOnly;

--- a/scripts/VTS/IRF.generate_lookup_table_parts.sh
+++ b/scripts/VTS/IRF.generate_lookup_table_parts.sh
@@ -55,9 +55,53 @@ RECID=$6
 SIMTYPE=$7
 PARTICLE_TYPE="gamma"
 
+# Hack to scale sizes based on epochs to approx. correct for drop in reflectivity+gain.
+_sizecallineraw=$(grep "* T " ${VERITAS_EVNDISP_AUX_DIR}/ParameterFiles/MSCW.sizecal.runparameter | grep " ${EPOCH} ")
+EPOCH_LABEL=$(echo "$_sizecallineraw" | awk '{print $3}')
+EPOCH_RUNSTART=$(echo "$_sizecallineraw" | awk '{print $4}')
+EPOCH_RUNSTOP=$(echo "$_sizecallineraw" | awk '{print $5}')
+EPOCH_T1SCALE=$(echo "$_sizecallineraw" | awk '{print $6}')
+EPOCH_T2SCALE=$(echo "$_sizecallineraw" | awk '{print $7}')
+EPOCH_T3SCALE=$(echo "$_sizecallineraw" | awk '{print $8}')
+EPOCH_T4SCALE=$(echo "$_sizecallineraw" | awk '{print $9}')
+EPOCH_SIMS=$(echo "$EPOCH_LABEL" | awk -F"_" '{print $1}')
+
+# Validation of the line
+if [ "${EPOCH_SIMS}" != "V4" ]&&[ "${EPOCH_SIMS}" != "V5" ]&&[ "${EPOCH_SIMS}" != "V6" ]; then
+    echo "$EPOCH LABEL ${EPOCH_LABEL} should include either V4, V5 or V6 plus maybe a suffix separated by _"
+    exit 1
+fi
+if ! [[ "${EPOCH_RUNSTART}" > 0 ]]&&[[ "${EPOCH_RUNSTART}" < 999999 ]]; then
+    echo "RUNSTART ${EPOCH_RUNSTART} should be an integer"
+    exit 1
+fi
+if ! [[ "${EPOCH_RUNSTOP}" > 0 ]]&&[[ "${EPOCH_RUNSTOP}" < 999999 ]]; then
+    echo "RUNSTART ${EPOCH_RUNSTART} should be an integer"
+    exit 1
+fi
+if ! [ $(echo ${EPOCH_T1SCALE} | awk '$1>0.0 && $1<2.0 {print 1}')==1 ]; then
+    echo "T1 SCALING ${EPOCH_T1SCALE} is invalid"
+    exit 1
+fi
+if ! [ $(echo ${EPOCH_T2SCALE} | awk '$1>0.0 && $1<2.0 {print 1}')==1 ]; then
+    echo "T2 SCALING ${EPOCH_T2SCALE} is invalid"
+    exit 1
+fi
+if ! [ $(echo ${EPOCH_T3SCALE} | awk '$1>0.0 && $1<2.0 {print 1}')==1 ]; then
+    echo "T3 SCALING ${EPOCH_T3SCALE} is invalid"
+    exit 1
+fi
+if ! [ $(echo ${EPOCH_T4SCALE} | awk '$1>0.0 && $1<2.0 {print 1}')==1 ]; then
+    echo "T4 SCALING ${EPOCH_T4SCALE} is invalid"
+    exit 1
+fi
+
+SIZESCALING="$EPOCH_T1SCALE,$EPOCH_T2SCALE,$EPOCH_T3SCALE,$EPOCH_T4SCALE"
+
 # input directory containing evndisp products
 if [[ -n "$VERITAS_IRFPRODUCTION_DIR" ]]; then
-    INDIR="$VERITAS_IRFPRODUCTION_DIR/$EDVERSION/$SIMTYPE/${EPOCH}_ATM${ATM}_${PARTICLE_TYPE}/ze${ZA}deg_offset${WOBBLE}deg_NSB${NOISE}MHz"
+    #INDIR="$VERITAS_IRFPRODUCTION_DIR/$EDVERSION/$SIMTYPE/${EPOCH}_ATM${ATM}_${PARTICLE_TYPE}/ze${ZA}deg_offset${WOBBLE}deg_NSB${NOISE}MHz"
+    INDIR="$VERITAS_IRFPRODUCTION_DIR/$EDVERSION/$SIMTYPE/${EPOCH_SIMS}_ATM${ATM}_${PARTICLE_TYPE}/ze${ZA}deg_offset${WOBBLE}deg_NSB${NOISE}MHz"
 fi
 if [[ ! -d $INDIR ]]; then
     echo "Error, could not locate input directory. Locations searched:"
@@ -68,7 +112,7 @@ echo "Input file directory: $INDIR"
 
 # Output file directory
 if [[ ! -z $VERITAS_IRFPRODUCTION_DIR ]]; then
-    ODIR="$VERITAS_IRFPRODUCTION_DIR/$EDVERSION/$SIMTYPE/${EPOCH}_ATM${ATM}_${PARTICLE_TYPE}/Tables"
+    ODIR="$VERITAS_IRFPRODUCTION_DIR/$EDVERSION/$SIMTYPE/${EPOCH_LABEL}_ATM${ATM}_${PARTICLE_TYPE}/Tables"
 fi
 echo "Output file directory: $ODIR"
 mkdir -p $ODIR
@@ -95,6 +139,7 @@ sed -e "s|ZENITHANGLE|$ZA|" \
     -e "s|ATMOSPHERE|$ATM|" \
     -e "s|RECONSTRUCTIONID|$RECID|" \
     -e "s|SIMULATIONTYPE|$SIMTYPE|" \
+    -e "s|SIZESCALING|$SIZESCALING|" \
     -e "s|INPUTDIR|$INDIR|" \
     -e "s|OUTPUTDIR|$ODIR|" $SUBSCRIPT.sh > $FSCRIPT.sh
 

--- a/scripts/VTS/helper_scripts/IRF.lookup_table_parallel_sub.sh
+++ b/scripts/VTS/helper_scripts/IRF.lookup_table_parallel_sub.sh
@@ -14,6 +14,7 @@ RECID=RECONSTRUCTIONID
 SIMTYPE=SIMULATIONTYPE
 INDIR=INPUTDIR
 ODIR=OUTPUTDIR
+SSCALING=SIZESCALING
 
 TABFILE="table_${SIMTYPE}_${ZA}deg_${WOBBLE}wob_noise${NOISE}_${EPOCH}_ATM${ATM}_ID${RECID}"
 
@@ -21,7 +22,9 @@ TABFILE="table_${SIMTYPE}_${ZA}deg_${WOBBLE}wob_noise${NOISE}_${EPOCH}_ATM${ATM}
 rm -f "$ODIR/$TABFILE.root"
 rm -f "$ODIR/$TABFILE.log"
 
+echo "----------> Debug: size scaling set to $SSCALING"
+
 # make the table part
-$EVNDISPSYS/bin/mscw_energy -filltables=1 -limitEnergyReconstruction -write1DHistograms -inputfile "$INDIR/*[0-9].root" -tablefile "$ODIR/$TABFILE.root" -ze=$ZA -arrayrecid=$RECID -woff=$WOBBLE &> "$ODIR/$TABFILE.log"
+$EVNDISPSYS/bin/mscw_energy -filltables=1 -limitEnergyReconstruction -write1DHistograms -inputfile "$INDIR/*[0-9].root" -tablefile "$ODIR/$TABFILE.root" -ze=$ZA -arrayrecid=$RECID -woff=$WOBBLE -sizecorrection=$SSCALING &> "$ODIR/$TABFILE.log"
 
 exit

--- a/scripts/VTS/helper_scripts/IRF.mscw_energy_MC_sub.sh
+++ b/scripts/VTS/helper_scripts/IRF.mscw_energy_MC_sub.sh
@@ -12,6 +12,7 @@ ZA=ZENITHANGLE
 NOISE=NOISELEVEL
 WOBBLE=WOBBLEOFFSET
 NROOTFILES=NFILES
+SSCALING=SIZESCALING
 RECID="RECONSTRUCTIONID"
 
 #loop over all reconstruction IDs
@@ -54,7 +55,7 @@ for ID in $RECID; do
 		  outputfilename="$DDIR/${OFILE}_$ITER.mscw.root"
 		  logfile="$OSUBDIR/${OFILE}_$ITER.log"
 	 fi
-	 $EVNDISPSYS/bin/mscw_energy $MOPT -inputfile $inputfilename -outputfile $outputfilename -noise=$NOISE &> $logfile
+	 $EVNDISPSYS/bin/mscw_energy $MOPT -inputfile $inputfilename -outputfile $outputfilename -sizecorrect=$SSCALING -noise=$NOISE &> $logfile
 # cp results file back to data directory and clean up
 	 outputbasename=$( basename $outputfilename )
     cp -f -v $outputfilename $OSUBDIR/$outputbasename

--- a/src/VTableLookup.cpp
+++ b/src/VTableLookup.cpp
@@ -674,10 +674,13 @@ void VTableLookup::fillLookupTable()
 				// get telescope type
 				ULong64_t t = iter_i_list_of_Tel_type->first;
 				
-				double* i_s2 = fData->getSize2( 1., t, fTLRunParameter->fUseSelectedImagesOnly );
+				//double* i_s2 = fData->getSize2( 1., t, fTLRunParameter->fUseSelectedImagesOnly );
 				double* i_r = fData->getDistanceToCore( t );
 				unsigned int i_type = fData->getNTel_type( t );
-				
+                                // Corrected size values ... 
+                                double* i_s2_fMSCWcorr   = fData->getSize2( fTLRunParameter->fMSCWSizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
+                                double* i_s2_fMSCLcorr   = fData->getSize2( fTLRunParameter->fMSCLSizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
+                                double* i_s2_fEnergycorr = fData->getSize2( fTLRunParameter->fEnergySizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
 				////////////////////////////////////////////////
 				// for zenith-angle == 0 deg fill all az bins
 				if( fabs( fData->getMCZe() ) < 3. )
@@ -686,16 +689,16 @@ void VTableLookup::fillLookupTable()
 					for( unsigned int a = 0; a < fTableAzBins; a++ )
 					{
 						// fill tables (get arrays filled for corresponding telescope type; one table per type)
-						fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+						fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCWcorr,
 								fData->getWidth( t ), idummy1, iEventWeight, idummy3, idummy1 );
-						fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+						fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCLcorr,
 								fData->getLength( t ), idummy1, iEventWeight, idummy3, idummy1 );
-						fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2, fData->getMCEnergyArray(),
-								idummy1, iEventWeight, idummy3, idummy1 );
+						fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fEnergycorr, 
+                                                                fData->getMCEnergyArray(), idummy1, iEventWeight, idummy3, idummy1 );
 						if( !fTLRunParameter->fLimitEnergyReconstruction )
 						{
 							fenergyEnergyvsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, fData->getMCEnergy(),
-									i_r, i_s2, idummy1, iEventWeight, idummy3, 0. );
+									i_r, i_s2_fEnergycorr, idummy1, iEventWeight, idummy3, 0. );
 						}
 					}
 				}
@@ -705,17 +708,17 @@ void VTableLookup::fillLookupTable()
 				{
 					unsigned int a = getAzBin( fData->getMCAz() );
 					// fill tables (get arrays filled for corresponding telescope type; one table per type)
-					fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+					fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCWcorr,
 							fData->getWidth( t ), idummy1, iEventWeight, idummy3, idummy1 );
-					fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+					fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCLcorr,
 							fData->getLength( t ), idummy1, iEventWeight, idummy3, idummy1 );
-					fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2, fData->getMCEnergyArray(),
-							idummy1, iEventWeight, idummy3, idummy1 );
+					fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fEnergycorr, 
+                                                        fData->getMCEnergyArray(), idummy1, iEventWeight, idummy3, idummy1 );
 							
 					if( !fTLRunParameter->fLimitEnergyReconstruction )
 					{
 						fenergyEnergyvsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, fData->getMCEnergy(),
-								i_r, i_s2, idummy1, iEventWeight, idummy3, 0. );
+								i_r, i_s2_fEnergycorr, idummy1, iEventWeight, idummy3, 0. );
 					}
 				}
 				i_Tel_type_counter++;
@@ -1439,30 +1442,35 @@ void VTableLookup::calculateMSFromTables( VTablesToRead* s, double esys )
 		return;
 	}
 	double i_dummy = 0.;
-	
-	double* i_s2 = fData->getSize2( 1., fTLRunParameter->fUseSelectedImagesOnly );
+
+        // Raw sizes, without scaling. 
+	//double* i_s2 = fData->getSize2( 1., fTLRunParameter->fUseSelectedImagesOnly );
+        // APPLY it only for MC, getSize2 gives the pointer to an array.
+        double* i_s2_fMSCWcorr   = fData->getSize2( fTLRunParameter->fMSCWSizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
+        double* i_s2_fMSCLcorr   = fData->getSize2( fTLRunParameter->fMSCLSizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
+        double* i_s2_fEnergycorr = fData->getSize2( fTLRunParameter->fEnergySizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
 	
 	f_calc_msc->setCalculateEnergies( false );
 	// calculate mscw
 	f_calc_msc->setVHistograms( s->hmscwMedian );
 	s->mscw = f_calc_msc->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-								i_s2, fData->getWidth(),
+								i_s2_fMSCWcorr, fData->getWidth(),
 								s->mscw_T, i_dummy, i_dummy, s->mscw_Tsigma );
 	// calculate mscl
 	f_calc_msc->setVHistograms( s->hmsclMedian );
 	s->mscl = f_calc_msc->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-								i_s2, fData->getLength(),
+								i_s2_fMSCLcorr, fData->getLength(),
 								s->mscl_T, i_dummy, i_dummy, s->mscl_Tsigma );
 	// calculate energy (method 1)
 	f_calc_energySR->setCalculateEnergies( true );
 	f_calc_energySR->setVHistograms( s->henergySRMedian );
 	s->energySR = f_calc_energySR->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-										 i_s2, 0,
+										 i_s2_fEnergycorr, 0,
 										 s->energySR_T, s->energySR_Chi2, s->energySR_dE, s->energySR_Tsigma );
 	// calculate energy (method 0)
 	f_calc_energy->setVHistograms( s->henergyERMedian );
 	s->energyER = f_calc_energy->calc( ( int )fData->getNTel(), fData->getMCEnergy(), fData->getDistanceToCore(),
-									   i_s2, s->energyER_T, s->energyER_Chi2, s->energyER_dE, esys );
+									   i_s2_fEnergycorr, s->energyER_T, s->energyER_Chi2, s->energyER_dE, esys );
 }
 
 

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -2270,6 +2270,7 @@ double* VTableLookupDataHandler::getDistanceToCore( ULong64_t iTelType )
 	return fR_telType;
 }
 
+// Old classes (global one-for-all-telescope scaling)
 double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelectedImagesOnly, bool iSize2 )
 {
 	for( unsigned int i = 0; i < getNTel(); i++ )
@@ -2311,6 +2312,64 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTe
 			else
 			{
 				fsize_telType[z] = fsize2[i] * iSizeCorrection;
+			}
+			z++;
+		}
+	}
+	return fsize_telType;
+}
+
+double* VTableLookupDataHandler::getSize( vector<double> iSizeCorrection, bool iSelectedImagesOnly, bool iSize2 )
+{
+        while (iSizeCorrection.size() < getNTel())
+        {
+            //std::cout << "Warning, not enough size scales, appending 1. " << std::endl;
+            iSizeCorrection.push_back(1);
+        }
+	for( unsigned int i = 0; i < getNTel(); i++ )
+	{
+		if( iSelectedImagesOnly && !fImgSel_list[i] )
+		{
+			fsizeCorr[i] = -99.;
+			continue;
+		}
+		if( !iSize2 )
+		{
+			fsizeCorr[i] = fsize[i] * iSizeCorrection[i];
+		}
+		else
+		{
+			fsizeCorr[i] = fsize2[i] * iSizeCorrection[i];
+		}
+	}
+	return fsizeCorr;
+}
+
+double* VTableLookupDataHandler::getSize( vector<double> iSizeCorrection,  ULong64_t iTelType, bool iSelectedImagesOnly, bool iSize2 )
+{
+	unsigned int z = 0;
+        while (iSizeCorrection.size() < getNTel())
+        {
+            //std::cout << "Warning, not enough size scales, required " << getNTel() << ", have " << iSizeCorrection.size() << ", appending 1. " << std::endl;
+            iSizeCorrection.push_back(1);
+        }
+	for( unsigned int i = 0; i < getNTel(); i++ )
+	{
+		if( fTel_type[i] == iTelType )
+		{
+			if( iSelectedImagesOnly && !fImgSel_list[i] )
+			{
+				fsize_telType[z] = -99.;
+				z++;
+				continue;
+			}
+			if( !iSize2 )
+			{
+				fsize_telType[z] = fsize[i] * iSizeCorrection[i];
+			}
+			else
+			{
+				fsize_telType[z] = fsize2[i] * iSizeCorrection[i];
 			}
 			z++;
 		}

--- a/src/VTableLookupRunParameter.cpp
+++ b/src/VTableLookupRunParameter.cpp
@@ -40,9 +40,9 @@ VTableLookupRunParameter::VTableLookupRunParameter()
 	fmaxdist = 50000.;
 	fSelectRandom = -1.;
 	fSelectRandomSeed = 17;
-	fMSCWSizecorrection = 1.;
-	fMSCLSizecorrection = 1.;
-	fEnergySizecorrection = 1.;
+	//fMSCWSizecorrection = 1.;
+	//fMSCLSizecorrection = 1.;
+	//fEnergySizecorrection = 1.;
 	
 	fLimitEnergyReconstruction = false;
 	
@@ -256,17 +256,67 @@ bool VTableLookupRunParameter::fillParameters( int argc, char* argv[] )
 				writeoption = "recreate";
 			}
 		}
+		else if( iTemp.find( "-sizecorrect" ) < iTemp.size() )
+		{
+                        float _scale;
+                        iTemp = iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() );
+                        for (unsigned long int k=0; k<999; k++)
+                        {
+                            _scale = atof( iTemp.substr( 0, iTemp.find( "," ) ).c_str() );
+                            fMSCWSizecorrection.push_back(_scale);
+                            fMSCLSizecorrection.push_back(_scale);
+                            fEnergySizecorrection.push_back(_scale);
+                            if ( iTemp.size() == (iTemp.substr( iTemp.find( "," ) + 1, iTemp.size())).size())
+                            {
+                                break;
+                            }
+                            iTemp = iTemp.substr( iTemp.find( "," ) + 1, iTemp.size() );
+                        }
+		}
 		else if( iTemp.find( "-sizemscwcorrect" ) < iTemp.size() )
 		{
-			fMSCWSizecorrection = atof( iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() ).c_str() );
+                        float _scale;
+                        iTemp = iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() );
+                        for (unsigned long int k=0; k<999; k++)
+                        {
+                            _scale = atof( iTemp.substr( 0, iTemp.find( "," ) ).c_str() );
+                            fMSCWSizecorrection.push_back(_scale);
+                            if ( iTemp.size() == (iTemp.substr( iTemp.find( "," ) + 1, iTemp.size())).size())
+                            {
+                                break;
+                            }
+                            iTemp = iTemp.substr( iTemp.find( "," ) + 1, iTemp.size() );
+                        }
 		}
 		else if( iTemp.find( "-sizemsclcorrect" ) < iTemp.size() )
 		{
-			fMSCLSizecorrection = atof( iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() ).c_str() );
+                        float _scale;
+                        iTemp = iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() );
+                        for (unsigned long int k=0; k<999; k++)
+                        {
+                            _scale = atof( iTemp.substr( 0, iTemp.find( "," ) ).c_str() );
+                            fMSCLSizecorrection.push_back(_scale);
+                            if ( iTemp.size() == (iTemp.substr( iTemp.find( "," ) + 1, iTemp.size())).size())
+                            {
+                                break;
+                            }
+                            iTemp = iTemp.substr( iTemp.find( "," ) + 1, iTemp.size() );
+                        }
 		}
 		else if( iTemp.find( "-sizeenergycorrect" ) < iTemp.size() )
 		{
-			fEnergySizecorrection = atof( iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() ).c_str() );
+                        float _scale;
+                        iTemp = iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() );
+                        for (unsigned long int k=0; k<999; k++)
+                        {
+                            _scale = atof( iTemp.substr( 0, iTemp.find( "," ) ).c_str() );
+                            fEnergySizecorrection.push_back(_scale);
+                            if ( iTemp.size() == (iTemp.substr( iTemp.find( "," ) + 1, iTemp.size())).size())
+                            {
+                                break;
+                            }
+                            iTemp = iTemp.substr( iTemp.find( "," ) + 1, iTemp.size() );
+                        }
 		}
 		else if( iTemp.find( "-noNo" ) < iTemp.size() )
 		{
@@ -527,18 +577,29 @@ void VTableLookupRunParameter::print( int iP )
 		        else if( fInterpolate == 2 ) fInterpolateString = "gaussian";
 		        cout << "interpolate lookup tables: " << fInterpolateString << endl; */
 	}
-	if( TMath::Abs( fMSCWSizecorrection - 1. ) > 1.e-2 )
-	{
-		cout << "size correction for mscw tables: " << fMSCWSizecorrection << endl;
-	}
-	if( TMath::Abs( fMSCLSizecorrection - 1. ) > 1.e-2 )
-	{
-		cout << "size correction for mscl tables: " << fMSCLSizecorrection << endl;
-	}
-	if( TMath::Abs( fEnergySizecorrection - 1. ) > 1.e-2 )
-	{
-		cout << "size correction for energy tables: " << fEnergySizecorrection << endl;
-	}
+       
+        // Check the average scaling factors among all telescopes. If it deviates from 1, print it 
+        if( fMSCWSizecorrection.size()>0 )
+        {
+        double_t fMSCWSizecorrection_sum=0;
+        for (unsigned int iS = 0; iS<fMSCWSizecorrection.size(); iS++) fMSCWSizecorrection_sum+=fMSCWSizecorrection[iS];
+        double_t fMSCLSizecorrection_sum=0;
+        for (unsigned int iS = 0; iS<fMSCLSizecorrection.size(); iS++) fMSCLSizecorrection_sum+=fMSCLSizecorrection[iS];
+        double_t fEnergySizecorrection_sum=0;
+        for (unsigned int iS = 0; iS<fEnergySizecorrection.size(); iS++) fEnergySizecorrection_sum+=fEnergySizecorrection[iS];
+            if( TMath::Abs( fMSCWSizecorrection_sum/fMSCWSizecorrection.size() -1 ) > 1.e-2 )
+            {
+                    cout << "Mean size correction for mscw tables: " << fMSCWSizecorrection_sum/fMSCWSizecorrection.size() << endl;
+            }
+            if( TMath::Abs( fMSCLSizecorrection_sum/fMSCLSizecorrection.size() - 1. ) > 1.e-2 )
+            {
+                    cout << "Mean size correction for mscl tables: " << fMSCLSizecorrection_sum/fMSCLSizecorrection.size() << endl;
+            }
+            if( TMath::Abs( fEnergySizecorrection_sum/fEnergySizecorrection.size() - 1. ) > 1.e-2 )
+            {
+                    cout << "Mean size correction for energy tables: " << fEnergySizecorrection_sum/fEnergySizecorrection.size() << endl;
+            }
+        }
 	
 	if( iP >= 1 )
 	{


### PR DESCRIPTION
MC event size-scale corrections. Different periods can be defined through a separated runparameter file `MSCW.sizecal.runparameter` file containing the following:

```
Table with average-year mirror reflectivities (after normalization w.r.t GRISUDET)
  t ID RUN_START RUN_STOP T1 T2 T3 T4
* T V4 00000 46641 1.00 1.00 1.00 1.00
* T V5 46642 63372 1.00 1.00 1.00 1.00
* T V6 63373 69492 1.00 1.00 1.00 1.00
* T V6_2014 69492 74121 0.90 0.98 0.82 0.85
* T V6_2015 74122 78239 0.77 0.86 0.77 0.78
* T V6_2016 78240 82587 0.78 0.83 0.73 0.81
* T V6_2017 82588 86848 0.72 0.82 0.68 0.74
* T V6_2018 86849 90608 0.71 0.78 0.72 0.73
* T V6_2019 90609 99000 0.68 0.72 0.65 0.68 
```

where the T comes from Transmission, as we may need to define an additional table with gains in the future if we see some significant deviations in the gain too ... (for now I'm fully ignoring that). 