### PR TITLE
Allow ignoring acceptances in anasum_parallel_from_runlist

### DIFF
--- a/scripts/VTS/ANALYSIS.anasum_parallel_from_runlist.sh
+++ b/scripts/VTS/ANALYSIS.anasum_parallel_from_runlist.sh
@@ -21,7 +21,7 @@ required parameters:
                             (e.g., soft2tel, moderate3tel, moderateExt2tel, BDTmoderate2tel, etc.)
     
     <background model>      background model
-                            (RE = reflected region, RB = ring background)
+                            (RE = reflected region, RB = ring background, IGNOREACCEPTANCE = RE without ACCEPTANCE)
     
 optional parameters:
 
@@ -139,6 +139,7 @@ elif [[ $CUT == *ExtendedSource-* ]]; then
     CUTRADACC=${CUT/-ExtendedSource-/"-"}
     echo $CUTRADACC
 fi
+
 RADACC="radialAcceptance-${IRFVERSION}-${AUXVERSION}-${SIMTYPE}-Cut-${CUTRADACC}-${METH}-VX-TX.root"
 
 echo $CUTFILE
@@ -149,6 +150,10 @@ echo $RADACC
 if [[ "$BACKGND" == *RB* ]]; then
     BM="RB"
     BMPARAMS="0.6 20"
+elif [[ "$BACKGND" == *IGNOREACCEPTANCE* ]]; then
+    BM="RE"
+    BMPARAMS="0.1 2 6"
+    RADACC="IGNOREACCEPTANCE"
 elif [[ "$BACKGND" == *RE* ]]; then
     BM="RE"
     BMPARAMS="0.1 2 6"
@@ -212,9 +217,13 @@ for RUN in ${RUNS[@]}; do
     EFFAREARUN=${EFFAREA/VX/$EPOCH}
     EFFAREARUN=${EFFAREARUN/TX/$TELTOANA}
     EFFAREARUN=${EFFAREARUN/XX/$ATMO}
-    RADACCRUN=${RADACC/VX/$EPOCH}
-    RADACCRUN=${RADACCRUN/TX/$TELTOANA}
-
+    if [ "$RADACC" != "IGNOREACCEPTANCE" ]; then 
+        RADACCRUN=${RADACC/VX/$EPOCH}
+        RADACCRUN=${RADACCRUN/TX/$TELTOANA}
+    else
+        RADACCRUN=$RADACC
+    fi
+    
     if [[ $CUTS = *frogs* ]]; then
        RADACCRUN="radialAcceptance-v470-auxv01-CARE_June1425-Cut-NTel2-PointSource-Moderate-GEO-V6-T1234.root"
        EFFAREARUN="effArea-v461-141017-CARE-N2_001-003-005CU_index2.5-GEO-V6-ATM21-T1234.root"

--- a/scripts/VTS/ANALYSIS.evndisp.sh
+++ b/scripts/VTS/ANALYSIS.evndisp.sh
@@ -76,7 +76,20 @@ exec 5>&1
 RLIST=$1
 [[ "$2" ]] && ODIR=$2 || ODIR="$VERITAS_USER_DATA_DIR/analysis/Results/$EDVERSION/"
 mkdir -p $ODIR
-[[ "$3" ]] && ACUTS=$3 || ACUTS=EVNDISP.reconstruction.runparameter
+
+# Try to use the correct reconstruction runparameters. For V4 and V5 the default is GRISU / SumWindow6-noDISP.
+if [[ "$SIMTYPE" == "CARE"* ]]; then
+    ACUTS_AUTO=EVNDISP.reconstruction.runparameter
+elif [[ "$SIMTYPE" == "GRISU"* ]]; then 
+    ACUTS_AUTO=EVNDISP.reconstruction.runparameter.SumWindow6-noDISP
+else
+    echo "WARNING: Unknown simulation type $SIMTYPE, please check ..."
+    sleep 2
+    ACUTS_AUTO=EVNDISP.reconstruction.runparameter
+fi
+
+[[ "$3" ]] && ACUTS=$3 || ACUTS=$ACUTS_AUTO #EVNDISP.reconstruction.runparameter
+#[[ "$3" ]] && ACUTS=$3 || ACUTS=EVNDISP.reconstruction.runparameter
 [[ "$4" ]] && CALIB=$4 || CALIB=1
 [[ "$5" ]] && MODEL3D=$5 || MODEL3D=0
 [[ "$6" ]] && TELTOANA=$6 || TELTOANA=1234

--- a/scripts/VTS/IRF.generate_effective_area_parts.sh
+++ b/scripts/VTS/IRF.generate_effective_area_parts.sh
@@ -50,7 +50,7 @@ bash $(dirname "$0")"/helper_scripts/UTILITY.script_init.sh"
 
 # EventDisplay version
 EDVERSION=`$EVNDISPSYS/bin/makeEffectiveArea --version | tr -d .| sed -e 's/[a-Z]*$//'`
-EDVERSION=`$EVNDISPSYS/bin/makeEffectiveArea --version | tr -d .`
+#EDVERSION=`$EVNDISPSYS/bin/makeEffectiveArea --version | tr -d .` # this is inconsistent with the mscw command
 
 # Parse command line arguments
 CUTSFILE="$1"

--- a/scripts/VTS/IRF.production.sh
+++ b/scripts/VTS/IRF.production.sh
@@ -43,6 +43,11 @@ optional parameters:
 exit
 fi
 
+# We need to be in the IRF.production.sh directory so that subscripts are called
+# (we call them ./).
+olddir=$(pwd)
+cd $(dirname "$0")
+
 # Run init script
 bash $(dirname "$0")"/helper_scripts/UTILITY.script_init.sh"
 [[ $? != "0" ]] && exit 1
@@ -72,8 +77,13 @@ if [[ ${SIMTYPE:0:5} = "GRISU" ]]; then
        NSB_LEVELS=( 200 )
        WOBBLE_OFFSETS=( 0.5 )
     fi
+elif [ "${SIMTYPE}" = "CARE_June1702" ]; then
+    # CARE_June1702 simulation parameters
+    ZENITH_ANGLES=( 00 20 30 35 40 45 50 55 )
+    NSB_LEVELS=( 50 75 100 130 160 200 250 300 350 400 450 )
+    WOBBLE_OFFSETS=( 0.5 )
 elif [ ${SIMTYPE:0:4} = "CARE" ]; then
-    # CARE simulation parameters
+    # Older CARE simulation parameters
     ZENITH_ANGLES=( 00 20 30 35 40 45 50 55 60 65 )
     NSB_LEVELS=( 50 80 120 170 230 290 370 450 )
     WOBBLE_OFFSETS=( 0.5 )
@@ -89,7 +99,7 @@ fi
 # Set gamma/hadron cuts
 if [[ $CUTSLISTFILE != "" ]]; then
     if [ ! -f $CUTSLISTFILE ]; then
-        echo "Error, cuts list file not found, exiting..."
+        echo "Error, cuts list file $CUTSLISTFILE not found, exiting..."
         exit 1
     fi
     # read file containing list of cuts
@@ -223,5 +233,7 @@ for VX in $EPOCH; do
     done #ATM
 done  #VX
 
+# Go back to the original user directory.
+cd $olddir
 exit
 

--- a/scripts/VTS/submissionCommands.dat
+++ b/scripts/VTS/submissionCommands.dat
@@ -12,6 +12,7 @@
 
 # DESY batch farm
   qsub -V -terse -l os=sl6 -l h_cpu=$h_cpu -l h_rss=$h_vmem -l tmpdir_size=$tmpdir_size -o $LOGDIR/ -e $LOGDIR/
+  qsub -V -terse -l os=sl7 -l h_cpu=$h_cpu -l h_rss=$h_vmem -l tmpdir_size=$tmpdir_size -o $LOGDIR/ -e $LOGDIR/
 
 # DESY batch farm -- high priority
  qsub -P cta_high -V -terse -l os=sl6 -l h_cpu=$h_cpu -l h_vmem=$h_vmem -l tmpdir_size=$tmpdir_size -o $LOGDIR/ -e $LOGDIR/


### PR DESCRIPTION
Try to set the correct reconstruction runparameter by default (for V4 and V5 it is the SumWindow6-noDISP). Has no effect if the user specifies it.

Unify EDVERSIONS.

Add os=sl7 to submission commands