### PR TITLE
Energy scale / size scaling factors

### DIFF
--- a/scripts/VTS/IRF.combine_effective_area_parts.sh
+++ b/scripts/VTS/IRF.combine_effective_area_parts.sh
@@ -49,7 +49,7 @@ bash $(dirname "$0")"/helper_scripts/UTILITY.script_init.sh"
 
 # EventDisplay version
 EDVERSION=`$EVNDISPSYS/bin/combineEffectiveAreas --version | tr -d .| sed -e 's/[a-Z]*$//'`
-EDVERSION=`$EVNDISPSYS/bin/combineEffectiveAreas --version | tr -d .`
+#EDVERSION=`$EVNDISPSYS/bin/combineEffectiveAreas --version | tr -d .`
 
 # Parse command line arguments
 CUTSFILE=$1

--- a/src/VTableLookup.cpp
+++ b/src/VTableLookup.cpp
@@ -674,13 +674,14 @@ void VTableLookup::fillLookupTable()
 				// get telescope type
 				ULong64_t t = iter_i_list_of_Tel_type->first;
 				
-				//double* i_s2 = fData->getSize2( 1., t, fTLRunParameter->fUseSelectedImagesOnly );
+                                // This should be already the corrected/scaled size value for MC. 
+				double* i_s2 = fData->getSize2( 1., t, fTLRunParameter->fUseSelectedImagesOnly );
 				double* i_r = fData->getDistanceToCore( t );
 				unsigned int i_type = fData->getNTel_type( t );
-                                // Corrected size values ... 
-                                double* i_s2_fMSCWcorr   = fData->getSize2( fTLRunParameter->fMSCWSizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
-                                double* i_s2_fMSCLcorr   = fData->getSize2( fTLRunParameter->fMSCLSizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
-                                double* i_s2_fEnergycorr = fData->getSize2( fTLRunParameter->fEnergySizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
+                                // Corrected size values (old, only applies to the MC) ... 
+                                //double* i_s2_fMSCWcorr   = fData->getSize2( fTLRunParameter->fMSCWSizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
+                                //double* i_s2_fMSCLcorr   = fData->getSize2( fTLRunParameter->fMSCLSizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
+                                //double* i_s2_fEnergycorr = fData->getSize2( fTLRunParameter->fEnergySizecorrection, t, fTLRunParameter->fUseSelectedImagesOnly ); 
 				////////////////////////////////////////////////
 				// for zenith-angle == 0 deg fill all az bins
 				if( fabs( fData->getMCZe() ) < 3. )
@@ -689,16 +690,16 @@ void VTableLookup::fillLookupTable()
 					for( unsigned int a = 0; a < fTableAzBins; a++ )
 					{
 						// fill tables (get arrays filled for corresponding telescope type; one table per type)
-						fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCWcorr,
+						fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
 								fData->getWidth( t ), idummy1, iEventWeight, idummy3, idummy1 );
-						fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCLcorr,
+						fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
 								fData->getLength( t ), idummy1, iEventWeight, idummy3, idummy1 );
-						fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fEnergycorr, 
+						fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2, 
                                                                 fData->getMCEnergyArray(), idummy1, iEventWeight, idummy3, idummy1 );
 						if( !fTLRunParameter->fLimitEnergyReconstruction )
 						{
 							fenergyEnergyvsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, fData->getMCEnergy(),
-									i_r, i_s2_fEnergycorr, idummy1, iEventWeight, idummy3, 0. );
+									i_r, i_s2, idummy1, iEventWeight, idummy3, 0. );
 						}
 					}
 				}
@@ -708,17 +709,17 @@ void VTableLookup::fillLookupTable()
 				{
 					unsigned int a = getAzBin( fData->getMCAz() );
 					// fill tables (get arrays filled for corresponding telescope type; one table per type)
-					fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCWcorr,
+					fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
 							fData->getWidth( t ), idummy1, iEventWeight, idummy3, idummy1 );
-					fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fMSCLcorr,
+					fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
 							fData->getLength( t ), idummy1, iEventWeight, idummy3, idummy1 );
-					fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2_fEnergycorr, 
+					fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2, 
                                                         fData->getMCEnergyArray(), idummy1, iEventWeight, idummy3, idummy1 );
 							
 					if( !fTLRunParameter->fLimitEnergyReconstruction )
 					{
 						fenergyEnergyvsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, fData->getMCEnergy(),
-								i_r, i_s2_fEnergycorr, idummy1, iEventWeight, idummy3, 0. );
+								i_r, i_s2, idummy1, iEventWeight, idummy3, 0. );
 					}
 				}
 				i_Tel_type_counter++;
@@ -1443,34 +1444,34 @@ void VTableLookup::calculateMSFromTables( VTablesToRead* s, double esys )
 	}
 	double i_dummy = 0.;
 
-        // Raw sizes, without scaling. 
-	//double* i_s2 = fData->getSize2( 1., fTLRunParameter->fUseSelectedImagesOnly );
-        // APPLY it only for MC, getSize2 gives the pointer to an array.
-        double* i_s2_fMSCWcorr   = fData->getSize2( fTLRunParameter->fMSCWSizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
-        double* i_s2_fMSCLcorr   = fData->getSize2( fTLRunParameter->fMSCLSizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
-        double* i_s2_fEnergycorr = fData->getSize2( fTLRunParameter->fEnergySizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
+        // MNR Get the size untouched, the size was already scaled if needed when reading the event. 
+	double* i_s2 = fData->getSize2( 1., fTLRunParameter->fUseSelectedImagesOnly );
+        // Old. APPLY it only for MC, getSize2 gives the pointer to an array. 
+        //double* i_s2_fMSCWcorr   = fData->getSize2( fTLRunParameter->fMSCWSizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
+        //double* i_s2_fMSCLcorr   = fData->getSize2( fTLRunParameter->fMSCLSizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
+        //double* i_s2_fEnergycorr = fData->getSize2( fTLRunParameter->fEnergySizecorrection, fTLRunParameter->fUseSelectedImagesOnly ); 
 	
 	f_calc_msc->setCalculateEnergies( false );
 	// calculate mscw
 	f_calc_msc->setVHistograms( s->hmscwMedian );
 	s->mscw = f_calc_msc->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-								i_s2_fMSCWcorr, fData->getWidth(),
+								i_s2, fData->getWidth(),
 								s->mscw_T, i_dummy, i_dummy, s->mscw_Tsigma );
 	// calculate mscl
 	f_calc_msc->setVHistograms( s->hmsclMedian );
 	s->mscl = f_calc_msc->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-								i_s2_fMSCLcorr, fData->getLength(),
+								i_s2, fData->getLength(),
 								s->mscl_T, i_dummy, i_dummy, s->mscl_Tsigma );
 	// calculate energy (method 1)
 	f_calc_energySR->setCalculateEnergies( true );
 	f_calc_energySR->setVHistograms( s->henergySRMedian );
 	s->energySR = f_calc_energySR->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-										 i_s2_fEnergycorr, 0,
+										 i_s2, 0,
 										 s->energySR_T, s->energySR_Chi2, s->energySR_dE, s->energySR_Tsigma );
 	// calculate energy (method 0)
 	f_calc_energy->setVHistograms( s->henergyERMedian );
 	s->energyER = f_calc_energy->calc( ( int )fData->getNTel(), fData->getMCEnergy(), fData->getDistanceToCore(),
-									   i_s2_fEnergycorr, s->energyER_T, s->energyER_Chi2, s->energyER_dE, esys );
+									   i_s2, s->energyER_T, s->energyER_Chi2, s->energyER_dE, esys );
 }
 
 

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -464,7 +464,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 			fdist[i] = ftpars[i]->dist;
                         // MNR: We need to correct here the sizes too.
 			fsize[i] = ftpars[i]->size * fTLRunParameter->fEnergySizecorrection[i];
-			fsize2[i] = ftpars[i]->size2 * fTLRunParameter->fEnergySizecorrection[i]*fTLRunParameter->fEnergySizecorrection[i];
+			fsize2[i] = ftpars[i]->size2 * fTLRunParameter->fEnergySizecorrection[i];
 			floss[i] = ftpars[i]->loss;
 			ffracLow[i] = ftpars[i]->fracLow;
 			fwidth[i] = ftpars[i]->width;
@@ -2287,7 +2287,7 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelected
 		}
 		else
 		{
-			fsizeCorr[i] = fsize2[i] * iSizeCorrection*iSizeCorrection;
+			fsizeCorr[i] = fsize2[i] * iSizeCorrection;
 		}
 	}
 	return fsizeCorr;
@@ -2312,7 +2312,7 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTe
 			}
 			else
 			{
-				fsize_telType[z] = fsize2[i] * iSizeCorrection*iSizeCorrection;
+				fsize_telType[z] = fsize2[i] * iSizeCorrection;
 			}
 			z++;
 		}
@@ -2335,7 +2335,7 @@ double* VTableLookupDataHandler::getSize( vector<double> iSizeCorrection, bool i
 		}
 		else
 		{
-			fsizeCorr[i] = fsize2[i] * iSizeCorrection[i]*iSizeCorrection[i];
+			fsizeCorr[i] = fsize2[i] * iSizeCorrection[i];
 		}
 	}
 	return fsizeCorr;
@@ -2360,7 +2360,7 @@ double* VTableLookupDataHandler::getSize( vector<double> iSizeCorrection,  ULong
 			}
 			else
 			{
-				fsize_telType[z] = fsize2[i] * iSizeCorrection[i]*iSizeCorrection[i];
+				fsize_telType[z] = fsize2[i] * iSizeCorrection[i];
 			}
 			z++;
 		}


### PR DESCRIPTION
Maybe-final (thanks Tarek) implementation of size scaling factors at MSCW level.

Note that I haven't removed the reading size functions with vector scaling. They are not used anymore, but I'm not sure if they could be used in the future. Maybe we drop them in the next commit or we just don't port them to V500. 