### PR TITLE
Fix of zenith angle setting for IRF calculations

### DIFF
--- a/src/VTableLookup.cpp
+++ b/src/VTableLookup.cpp
@@ -795,8 +795,10 @@ void VTableLookup::readLookupTable()
 		}
 		
 		// get zenith angle for first valid MC event from MC files
-		if( bFirst && fData->getMCEnergy() > 0.001 )
+		if( bFirst && fData->getMCEnergy() > 0.001 
+                && fTLRunParameter->ze < 0. )
 		{
+                        cout << "\t\t setting IRF ze from first event" << endl;
 			if( fNTel > 0 )
 			{
 				fTLRunParameter->ze = TMath::Floor( ( 90. - fData->getTelElevation() ) + 0.5 );

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -1337,6 +1337,11 @@ bool VTableLookupDataHandler::readRunParameter()
 			}
 			VEvndispRunParameter* iPar = ( VEvndispRunParameter* ) ifInput.Get( "runparameterV2" );
 			VEvndispReconstructionParameter* iA = ( VEvndispReconstructionParameter* )ifInput.Get( "EvndispReconstructionParameter" );
+                        VMonteCarloRunHeader* iMC = ( VMonteCarloRunHeader* )ifInput.Get( "MC_runheader" );
+                        if( iMC )
+                        {
+                             fTLRunParameter->ze = iMC->getMeanZenithAngle_Deg();
+                        }
 			vector< unsigned int > iTelToAnalyze;
 			if( iPar )
 			{

--- a/src/VTableLookupRunParameter.cpp
+++ b/src/VTableLookupRunParameter.cpp
@@ -13,7 +13,7 @@ VTableLookupRunParameter::VTableLookupRunParameter()
 	
 	outputfile = "";
 	tablefile = "";
-	ze = 0.;
+	ze = -1.;
 	isMC = false;
 	fInterpolate = 0;
 	fUseMedianEnergy = 1;


### PR DESCRIPTION
Zenith angles for IRFs were sometimes 39 instead of 40 deg
due to floating point inaccuracies.

Fixed this by reading directly the zenith angle
from the MC run header.

Note that this might not work for simulations using
a range of zenith angles