### PR TITLE
Optional/Suggested change: Create one LOG directory for each 100-second chunk 

### DIFF
--- a/scripts/VTS/IRF.combine_lookup_table_parts.sh
+++ b/scripts/VTS/IRF.combine_lookup_table_parts.sh
@@ -70,7 +70,7 @@ fi
 
 # run scripts and output are written into this directory
 DATE=`date +"%y%m%d"`
-LOGDIR="$VERITAS_USER_LOG_DIR/$DATE/MSCW.MAKETABLES"
+LOGDIR="$VERITAS_USER_LOG_DIR/$DATE/MSCW.MAKETABLES/$(date +%s | cut -c -8)/"
 echo -e "Log files will be written to:\n$LOGDIR"
 mkdir -p $LOGDIR
 

--- a/scripts/VTS/IRF.generate_effective_area_parts.sh
+++ b/scripts/VTS/IRF.generate_effective_area_parts.sh
@@ -86,7 +86,7 @@ chmod g+w $ODIR
 
 # run scripts and output are written into this directory
 DATE=`date +"%y%m%d"`
-LOGDIR="$VERITAS_USER_LOG_DIR/$DATE/EFFAREA/${ZA}deg_${WOBBLE}wob_NOISE${NOISE}_${EPOCH}_ATM${ATM}_${PARTICLE_TYPE}_${RECID}/"
+LOGDIR="$VERITAS_USER_LOG_DIR/$DATE/EFFAREA/$(date +%s | cut -c -8)/${ZA}deg_${WOBBLE}wob_NOISE${NOISE}_${EPOCH}_ATM${ATM}_${PARTICLE_TYPE}_${RECID}/"
 echo -e "Log files will be written to:\n $LOGDIR"
 mkdir -p $LOGDIR
 

--- a/scripts/VTS/IRF.generate_lookup_table_parts.sh
+++ b/scripts/VTS/IRF.generate_lookup_table_parts.sh
@@ -103,7 +103,7 @@ chmod g+w $ODIR
 
 # run scripts and output are written into this directory
 DATE=`date +"%y%m%d"`
-LOGDIR="$VERITAS_USER_LOG_DIR/$DATE/MSCW.MAKETABLES"
+LOGDIR="$VERITAS_USER_LOG_DIR/$DATE/MSCW.MAKETABLES/$(date +%s | cut -c -8)/"
 echo -e "Log files will be written to:\n $LOGDIR"
 mkdir -p $LOGDIR
 


### PR DESCRIPTION
trying to avoid too many scripts and logs in the same directory which causes issues with DESY's cluster and gets the jobs in Eqw state. Particularly affects MAKETABLES, EFFECTIVEAREAS. May affect EVNDISP stage too, but probably no one runs the entire IRF production in one piece anways for that step as it is a very large computing time required. 