### PR TITLE
Add option to write hadron events to dl3 tree

### DIFF
--- a/inc/VAnaSumRunParameter.h
+++ b/inc/VAnaSumRunParameter.h
@@ -187,7 +187,10 @@ class VAnaSumRunParameter : public TNamed, public VGlobalRunParameter
 		bool fWriteAllGammaToTree ; // WRITEALLGAMMATOTREE
 		int f2DAcceptanceMode ; // USE2DACCEPTANCE
 		bool fWriteEventTreeForCtools ; // WRITEEVENTTREEFORCTOOLS
-		
+		// write all events to DL3 tree (no gh cuts)
+        bool fWriteHadronicEvents ; 
+
+
 		// advanced analysis codes
 		bool fModel3D;
 		bool fDirectionModel3D;

--- a/inc/VStereoAnalysis.h
+++ b/inc/VStereoAnalysis.h
@@ -233,6 +233,8 @@ class VStereoAnalysis
 		int     fTreeCTOOLS_GregMonth ;
 		int     fTreeCTOOLS_GregDay   ;
 		double  fTreeCTOOLS_Acceptance ;
+        double  fTreeCTOOLS_MVA;
+        int     fTreeCTOOLS_IsGamma ;
 		VRadialAcceptance* fCTOOLSAcceptance ;
 		
 		TTree* fCDataTreeClone ;

--- a/src/VAnaSumRunParameter.cpp
+++ b/src/VAnaSumRunParameter.cpp
@@ -657,7 +657,18 @@ int VAnaSumRunParameter::readRunParameter( string i_filename )
 					fWriteEventTreeForCtools = true ;
 				}
 			}
-			
+		
+            // Write all events to DL3 tree. This will write out also hadronic events and
+            // add the MVA score and IsGamma to the tree.
+            else if ( temp == "WRITEHADRONICEVENTS" )
+            {
+                unsigned int tmpWriteAll = ( unsigned int )atoi( temp2.c_str() ) ;
+                if( tmpWriteAll == 1 )
+                {
+                    fWriteHadronicEvents = true ;
+                }
+            }
+
 			/// use Model3D analysis ///
 			else if( temp == "MODEL3DANALYSIS" )
 			{

--- a/src/VStereoAnalysis.cpp
+++ b/src/VStereoAnalysis.cpp
@@ -618,7 +618,7 @@ double VStereoAnalysis::fillHistograms( int icounter, int irun, double iAzMin, d
 			}
 
 			// fill a tree with current event for ctools converter
-			if( fIsOn && bIsGamma && fRunPara->fWriteEventTreeForCtools )
+			if( fIsOn && ( bIsGamma || fRunPara->fWriteHadronicEvents ) && fRunPara->fWriteEventTreeForCtools )
 			{
 				fill_TreeWithEventsForCtools( fDataRun, i_xderot, i_yderot, icounter, i_UTC, fEVDVersionSign );
 			}
@@ -2519,7 +2519,12 @@ bool VStereoAnalysis::init_TreeWithEventsForCtools( int irun ) // WRITEEVENTTREE
 	fTreeWithEventsForCtools->Branch( "GregMonth"     , &fTreeCTOOLS_GregMonth     , "GregMonth/D" );
 	fTreeWithEventsForCtools->Branch( "GregDay"       , &fTreeCTOOLS_GregDay       , "GregDay/D" );
 	fTreeWithEventsForCtools->Branch( "Acceptance"    , &fTreeCTOOLS_Acceptance    , "Acceptance/D" );
-	cout << endl;
+    if ( fRunPara->fWriteHadronicEvents )
+    {
+        fTreeWithEventsForCtools->Branch( "MVA"           , &fTreeCTOOLS_MVA           , "MVA/D" );
+        fTreeWithEventsForCtools->Branch( "IsGamma"       , &fTreeCTOOLS_IsGamma       , "IsGamma/I" );
+    }
+    cout << endl;
 
 	// init acceptance critter
 	fCTOOLSAcceptance = new VRadialAcceptance( fRunPara->fRunList[0].fAcceptanceFile ) ;
@@ -2562,6 +2567,20 @@ void VStereoAnalysis::fill_TreeWithEventsForCtools( CData* c , double i_xderot, 
 	fTreeCTOOLS_MLR            = c->MLR ;
 	fTreeCTOOLS_EmissionHeight = c->EmissionHeight ; // height of shower maximum (in km) above telescope z-plane
 	fTreeCTOOLS_Acceptance     = fCTOOLSAcceptance->getAcceptance( i_xderot, i_yderot ) ;
+
+    if( fCuts && fRunPara->fWriteHadronicEvents )
+    {
+        fTreeCTOOLS_MVA = fCuts->getTMVA_EvaluationResult();
+        // bIsGamma = fCuts->isGamma( i, false, fIsOn );
+        if (bIsGamma)
+        {
+            fTreeCTOOLS_IsGamma = 1;
+        }
+        else
+        {
+            fTreeCTOOLS_IsGamma = 0;
+        }
+    }
 
 	// RA- and DEC-aligned Wobbles
 	fTreeCTOOLS_WobbleWest  = getWobbleWest()  ;


### PR DESCRIPTION
When using `WRITEHADRONICEVENTS` in the anasum run parameters, all events (no gh-cuts applied) are written to the DL3 tree.
The MVA score and IsGamma are added to the tree when using this option.