### PR TITLE
option to write all events to DL3 tree

### DIFF
--- a/inc/VAnaSumRunParameter.h
+++ b/inc/VAnaSumRunParameter.h
@@ -191,6 +191,9 @@ class VAnaSumRunParameter : public TNamed, public VGlobalRunParameter
 		bool fModel3D;
 		bool fDirectionModel3D;
 		
+        // add all events to DL3 tree, no gh cuts but add BDT score and IsGamma 
+        bool fWriteAllEvents;
+
 		// vector with all run parameters
 		vector< VAnaSumRunParameterDataClass > fRunList;
 		// map with all run parameters (sorted after onrun)

--- a/inc/VStereoAnalysis.h
+++ b/inc/VStereoAnalysis.h
@@ -198,6 +198,8 @@ class VStereoAnalysis
 		double  fDL3EventTree_El ;
 		double  fDL3EventTree_EmissionHeight ;
 		double  fDL3EventTree_Acceptance ;
+        double  fDL3EventTree_MVA;
+        UInt_t  fDL3EventTree_IsGamma;
 		VRadialAcceptance* fDL3_Acceptance;
 		
 		double  fDeadTimeStorage ;

--- a/src/VAnaSumRunParameter.cpp
+++ b/src/VAnaSumRunParameter.cpp
@@ -671,6 +671,16 @@ int VAnaSumRunParameter::readRunParameter( string i_filename )
 				}
 				
 			}
+            // Write all events to DL3 run. This will write out also hadronic events and
+            // add the MVA score and IsGamma to the tree.
+            else if ( temp == "WRITEALLEVENTS" )
+            {
+                unsigned int tmpWriteAll = ( unsigned int )atoi( temp2.c_str() ) ;
+                if( tmpWriteAll == 1 )
+                {
+                    fWriteAllEvents = true ;
+                }
+            }
 			else
 			{
 				cout << "Warning: unknown line in parameter file " << i_filename << ": " << endl;

--- a/src/VStereoAnalysis.cpp
+++ b/src/VStereoAnalysis.cpp
@@ -606,7 +606,7 @@ double VStereoAnalysis::fillHistograms( int icounter, int irun, double iAzMin, d
 			}
 
 			// fill a tree with current event for DL3 converter
-			if( fIsOn && bIsGamma )
+			if( fIsOn && ( bIsGamma || fRunPara->fWriteAllEvents ))
 			{
 				fill_DL3Tree( fDataRun, i_xderot, i_yderot, icounter, i_UTC );
 			}
@@ -2165,6 +2165,11 @@ bool VStereoAnalysis::init_DL3Tree( int irun, int icounter )
 	fDL3EventTree->Branch( "Xoff"          , &fDL3EventTree_Xoff          , "Xoff/D" );
 	fDL3EventTree->Branch( "Yoff"          , &fDL3EventTree_Yoff          , "Yoff/D" );
 	fDL3EventTree->Branch( "Acceptance"    , &fDL3EventTree_Acceptance    , "Acceptance/D" );
+    if ( fRunPara->fWriteAllEvents )
+    {
+        fDL3EventTree->Branch( "MVA"       , &fDL3EventTree_MVA,            "MVA/D" );
+        fDL3EventTree->Branch( "IsGamma"   , &fDL3EventTree_IsGamma,        "IsGamma/I" );
+    }
 	cout << endl;
 
 	// init radial acceptance class
@@ -2258,6 +2263,19 @@ void VStereoAnalysis::fill_DL3Tree( CData* c , double i_xderot, double i_yderot,
             fDL3EventTree_RA = 0.;
             fDL3EventTree_DEC = 0.;
         }
+    if ( fCuts && fRunPara->fWriteAllEvents )
+    {
+        fDL3EventTree_MVA = fCuts->getTMVA_EvaluationResult();
+        if ( bIsGamma )
+        {
+            fDL3EventTree_IsGamma = 1;
+        }
+        else
+        {
+            fDL3EventTree_IsGamma = 0;
+        }
+    }
+
 
 	if( fDL3EventTree )
 	{


### PR DESCRIPTION
Option to also write hadron-like events to DL3 tree. Also adds TMVA evaluation result and IsGamma to the DL3 event tree. 