### PR TITLE
Batch create camera images

### DIFF
--- a/inc/VDisplay.h
+++ b/inc/VDisplay.h
@@ -296,6 +296,8 @@ class VDisplay : public TGMainFrame
 		void     selectChannel( Int_t, Int_t, Int_t, TObject* );
 		void     updateCamera( Int_t );           //!< update camera view with new event
 		
+		void     makeFullMovie();
+		
 #ifndef __APPLE__
 		ClassDef( VDisplay, 1 )
 #endif

--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -322,6 +322,12 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		float fPWcleanThreshold;                  // cleaning threshold to use to determine hit pixels from the summed FADC charge (dc)
 		int fPWlimit;                             // limits the number of pixels transmitted per sector, if =0, then the function is ignored and no cut is applied on the generation of the trigger map
 		
+		// Movie Parameters
+		bool fMovieBool;                           // Are we making a movie?
+		string fMovieInput;                        // The input file with the event numbers
+		string fMovieOutputDir;                    // Where are we outputting the movie? 
+		string fMovieFrameOutput;                  // What format should we output the images in?
+		
 		// functions
 		void print();
 		void print( int iEV );

--- a/src/VDisplay.cpp
+++ b/src/VDisplay.cpp
@@ -3361,3 +3361,50 @@ void VDisplay::dumpImageBorderPixels()
 		}
 	}
 }
+
+void VDisplay::makeFullMovie(){
+	if (fEventLoop->getRunParameter()->fMovieBool)
+	{
+		//step 1, click the next button
+		fEventLoop->setNextEventStatus( true );
+		processEvent();
+		fEventLoop->setNextEventStatus( false );
+		// Step 2, Process
+		string inFile = fEventLoop->getRunParameter()->fMovieInput;
+		string outDir = fEventLoop->getRunParameter()->fMovieOutputDir;
+		ifstream inputFile(inFile);
+		int eventNum = 0;
+		while(inputFile >> eventNum){
+			char c_ev[200];
+			sprintf( c_ev, "searching for event %d",eventNum );
+			fStatusBar->SetText( c_ev, 1 );
+			fEventLoop->gotoEvent( eventNum );
+			if( eventNum != 0 )
+			{
+				sprintf( c_ev, "now at event %d", fEventLoop->getEventNumber() );
+				fStatusBar->SetText( c_ev, 1 );
+				updateCamera( fCameraDisplay );
+				// update analysis tabs if necessary
+				if( fTabAna->GetCurrent() == 1 && !fCameraTiming )
+				{
+					drawFADC( false );
+				}
+				else if( fTabAna->GetCurrent() == 6 )
+				{
+					fBirdsEye->draw( fCanvasBird );
+				}
+				else if( fTabAna->GetCurrent() == 3 )
+				{
+					drawPixelHistos();
+				}
+			}
+			ostringstream os;
+			os << outDir << "/run_" << fEventLoop->getRunNumber() << "_event_" << fEventLoop->getEventNumber() << "." << fEventLoop->getRunParameter()->fMovieFrameOutput;
+			string outFile = os.str();
+			fCanvasCamera->Print(outFile.c_str());
+		}
+		inputFile.close();
+		//Step 3, click quit button
+		CloseWindow();
+	}
+}

--- a/src/VReadRunParameter.cpp
+++ b/src/VReadRunParameter.cpp
@@ -103,6 +103,20 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 		{
 			fRunPara->fdisplaymode = atoi( iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() ).c_str() );
 		}
+		// movie mode
+		// movie <input file>,<output dir>,<image format>
+		else if( iTemp.find( "movie" ) < iTemp.size())
+		{
+			fRunPara->fdisplaymode = 1;
+			fRunPara->fMovieBool = true;
+			size_t commaLoc = iTemp2.find( "," );
+			size_t commaLoc2 = iTemp2.rfind( "," );
+			size_t betSize = commaLoc2 - commaLoc;
+			fRunPara->fMovieInput = iTemp2.substr( 0, commaLoc );
+			fRunPara->fMovieOutputDir = iTemp2.substr( commaLoc + 1, betSize - 1 );
+			fRunPara->fMovieFrameOutput = iTemp2.substr( commaLoc2 + 1 );
+			i++;
+		}
 		// muon mode
 		else if( iTemp.find( "muon" ) < iTemp.size() )
 		{

--- a/src/evndisp.cpp
+++ b/src/evndisp.cpp
@@ -75,7 +75,13 @@ int main( int argc, char* argv[] )
 		TApplication app( "app", &targv, argv );
 		VDisplay display( gClient->GetRoot(), fReadRunParameter->getRunParameter()->fw, fReadRunParameter->getRunParameter()->fh, &mainEventLoop );
 		display.Draw();
-		app.Run();
+		
+		if(fReadRunParameter->getRunParameter()->fMovieBool){			
+			display.makeFullMovie();
+		}else{
+			app.Run();
+		}
+		
 		
 	}
 	delete fReadRunParameter;


### PR DESCRIPTION
When creating a movie of events, putting each event number into the evndisp GUI then clicking next, then saving the camera to a file is quite tedious and the "make movie" command seems to only do sequential events. This pull request adds some code to automatically create the camera images based on an event list, which is then output into a directory in an user-specified format. After this is all done, it closes the GUI. This is triggered by an additional command line option "movie" which has the following format:
`evndisp ... movie <input file>,<output directory>,<output format> ...`
