### PR TITLE
Unless initialized this will always be non-false -> therefore always …

### DIFF
--- a/src/VAnaSumRunParameter.cpp
+++ b/src/VAnaSumRunParameter.cpp
@@ -155,6 +155,9 @@ VAnaSumRunParameter::VAnaSumRunParameter()
         // likelihood analysis
         fLikelihoodAnalysis = false;
 	
+	// Write all events to DL3 Tree
+	fWriteAllEvents = false;
+
 	// if 0, use default 1D radial acceptance
 	// if >0, use alternate 2D-dependent acceptance
 	f2DAcceptanceMode = 0 ; // USE2DACCEPTANCE


### PR DESCRIPTION
bool fWriteAllEvents is left uninitialized. This might be compiler dependent, but an uninitialized local bool is not false by default. So fWriteAllEvents is always "not false". The knock on effect is that all events are always written to the DL3 event tree.

