### PR TITLE
Likelihood first index

### DIFF
--- a/src/VEffectiveAreaCalculator.cpp
+++ b/src/VEffectiveAreaCalculator.cpp
@@ -1714,7 +1714,6 @@ bool VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms( TTree* iE
 			  i_hEsysMCRelative2D->AddDirectory(kFALSE);
 			  
 			  
-			  //cout << "From key-- " << fEsysMCRelative2D_map[i_ID]->GetBinContent(10,10) << endl;
 			}
 
 


### PR DESCRIPTION
Somehow missed this in the original testing. The response matrix is empty for all but the first (spectral) index entry in the response matrix. 

Defaulting the code to grab the first entry of the spectra index list when getting the response matrix. Otherwise the user needed to set the input spectral index to 1.6 (or what ever the first will be). Grabbing the first entry provides a bit of future proofing. 
