### PR TITLE
Determine C++ Standard Dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+print_cpp_std.out

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,14 @@ distdir = $(package)-$(version)
 ctapara = $(distdir).CTA.runparameter
 vtspara = $(package)-$(auxversion).VTS.aux
 #############################
+############################
+# Ensure ROOT has the same c++ version as the system's
+############################
+CPPSTD=$(shell get_cpp_std.sh)
+ROOTCPPSTD=$(shell root-config --cflags | cut -f2 -d " " | cut -f2 -d "=")
+ifneq($(CPPSTD), $(ROOTCPPSTD))
+  $(error "System's C++ Standard is different than the one compiled with ROOT; please re-compile ROOT with the appropiate flags!")
+endif
 #############################
 # check root version number
 #############################
@@ -142,7 +150,7 @@ endif
 ########################################################################################################################
 # compiler and linker general values
 CXX           = g++
-CXXFLAGS      = -O3 -g -Wall -fPIC -fno-strict-aliasing  -D_FILE_OFFSET_BITS=64 -D_LARGE_FILE_SOURCE -D_LARGEFILE64_SOURCE -std=c++11
+CXXFLAGS      = -O3 -g -Wall -fPIC -fno-strict-aliasing  -D_FILE_OFFSET_BITS=64 -D_LARGE_FILE_SOURCE -D_LARGEFILE64_SOURCE -std=$(CPPSTD)
 CXXFLAGS     += -I. -I./inc/
 CXXFLAGS     += $(VBFFLAG) $(DBFLAG) $(ROOT6FLAG) $(GSLFLAG) $(GSL2FLAG) $(FROGSFLAG) $(DCACHEFLAG)
 LD            = g++
@@ -163,7 +171,7 @@ endif
 ifeq ($(ARCH),Darwin)
 CXX           = clang++
 LD            = clang++
-CXXFLAGS    += -Wdeprecated-declarations -stdlib=libc++ -std=c++11
+CXXFLAGS    += -Wdeprecated-declarations -stdlib=libc++ -std=$(CPPSTD)
 LDFLAGS       = -bind_at_load
 DllSuf        = dylib
 UNDEFOPT      = dynamic_lookup

--- a/get_cpp_std.sh
+++ b/get_cpp_std.sh
@@ -1,0 +1,6 @@
+if [ ! -f "print_cpp_std.out" ]; then
+  CPP_PROGRAM="CiNpbmNsdWRlPGlvc3RyZWFtPgoKaW50IG1haW4oKSB7CglpZiAoX19jcGx1c3BsdXMgPT0gMjAxNzAzTCkgc3RkOjpjb3V0IDw8ICJDKysxN1xuIjsKCWVsc2UgaWYgKF9fY3BsdXNwbHVzID09IDIwMTQwMkwpIHN0ZDo6Y291dCA8PCAiQysrMTRcbiI7CgllbHNlIGlmIChfX2NwbHVzcGx1cyA9PSAyMDExMDNMKSBzdGQ6OmNvdXQgPDwgIkMrKzExXG4iOwoJZWxzZSBpZiAoX19jcGx1c3BsdXMgPT0gMTk5NzExTCkgc3RkOjpjb3V0IDw8ICJDKys5OFxuIjsKCWVsc2Ugc3RkOjpjb3V0IDw8ICJwcmUtc3RhbmRhcmQgQysrXG4iOwp9Cg=="
+  echo "$CPP_PROGRAM" | base64 -d | g++ -o print_cpp_std.out -x c++ -
+  chmod +x print_cpp_std.out
+fi
+./print_cpp_std.out | tr '[:upper:]' '[:lower:]'


### PR DESCRIPTION
The variety of standards used by collaboration members leads to compilation errors which require editing of the Makefile. This pull request adds a very simple shell script which compiles and runs the script found in this stackoverflow answer: https://stackoverflow.com/a/51536462. `Make` then checks this version against the one ROOT was compiled with to ensure compatibility. Then finally uses the determined C++ standard in the compile flags.