### PR TITLE
Fix of light curve data plotting for run numbers > 100000

### DIFF
--- a/inc/VAnaSumRunParameter.h
+++ b/inc/VAnaSumRunParameter.h
@@ -129,7 +129,11 @@ class VAnaSumRunParameterDataClass : public TNamed
 		
 		VAnaSumRunParameterDataClass();
 		~VAnaSumRunParameterDataClass() {}
-		ClassDef( VAnaSumRunParameterDataClass, 3 );
+        bool operator<(const VAnaSumRunParameterDataClass& x) const
+        {
+            return fRunOn < x.fRunOn;
+        }
+		ClassDef( VAnaSumRunParameterDataClass, 2 );
 };
 
 class VAnaSumRunParameter : public TNamed, public VGlobalRunParameter
@@ -258,9 +262,10 @@ class VAnaSumRunParameter : public TNamed, public VGlobalRunParameter
 		bool setTargetRADecJ2000( unsigned int i, double ra, double dec, string iTargetName );
 		bool setTargetRADec_currentEpoch( unsigned int i, double ra, double dec );
 		bool setTargetShifts( unsigned int i, double west, double north, double ra, double dec );
+        void sortRunList();
 		bool writeListOfExcludedSkyRegions();
 		bool getListOfExcludedSkyRegions( TFile* f );
 		
-		ClassDef( VAnaSumRunParameter, 14 ) ;
+		ClassDef( VAnaSumRunParameter, 15 ) ;
 };
 #endif

--- a/src/VAnaSum.cpp
+++ b/src/VAnaSum.cpp
@@ -142,6 +142,7 @@ void VAnaSum::initialize( string i_LongListFilename, string i_ShortListFilename,
 	///////////////////////////////////////////////////////////////////////////////////////////
 	if( fAnalysisRunMode == 1 )
 	{
+        fRunPara->sortRunList();
 		// loop over all files in run list and copy histograms
 		for( unsigned int j = 0; j < fRunPara->fRunList.size(); j++ )
 		{

--- a/src/VAnaSumRunParameter.cpp
+++ b/src/VAnaSumRunParameter.cpp
@@ -1879,7 +1879,10 @@ double VAnaSumRunParameter::getDeclinationFromStrings( string iDec1, string iDec
     return d_tt;
 }
 
-
+void VAnaSumRunParameter::sortRunList()
+{
+    sort( fRunList.begin(), fRunList.end() );
+}
 
 
 //==================================================================================

--- a/src/VFluxCalculation.cpp
+++ b/src/VFluxCalculation.cpp
@@ -2867,7 +2867,7 @@ unsigned int VFluxCalculation::getIndexOfRun( int iRun )
 		}
 	}
 	
-	return 99999;
+	return 999999;
 }
 
 //######################################################################################

--- a/src/VLightCurve.cpp
+++ b/src/VLightCurve.cpp
@@ -110,7 +110,7 @@ bool VLightCurve::initializeTeVLightCurve( string iAnaSumFile, double iDayInterv
 	fAnaSumFile = iAnaSumFile;
 	
 	// read full file to get an overview of all available runs
-	fFluxCombined = new VFluxCalculation( fAnaSumFile, 1, 0, 100000, -99., -99., false );
+	fFluxCombined = new VFluxCalculation( fAnaSumFile, 1, 0, 1000000, -99., -99., false );
 	if( fFluxCombined->IsZombie() )
 	{
 		cout << "VLightCurve::initializeLightCurve error reading anasum file" << endl;
@@ -133,11 +133,24 @@ bool VLightCurve::initializeTeVLightCurve( string iAnaSumFile, double iDayInterv
 	// get MJD for the case that no time limits are given
 	if( iMJDMin < 0 )
 	{
-		iMJDMin = TMath::Floor( fMJD[0] );
+        iMJDMin = 1000000;
+        for( unsigned int i = 0; i < fMJD.size(); i++ )
+        {
+            if( fMJD[i] > 0 && fMJD[i] < iMJDMin )
+            {
+                iMJDMin = TMath::Floor( fMJD[i] );
+            }
+        }
 	}
 	if( iMJDMax < 0 )
 	{
-		iMJDMax = TMath::Floor( fMJD[fMJD.size() - 2] ) + 1;
+        for( unsigned int i = 0; i < fMJD.size(); i++ )
+        {
+            if( fMJD[i] > 0 && fMJD[i] > iMJDMax )
+            {
+                iMJDMax = TMath::Floor( fMJD[i] ) + 1;
+            }
+        }
 	}
 	
 	// plotting parameters

--- a/src/VLightCurveData.cpp
+++ b/src/VLightCurveData.cpp
@@ -93,7 +93,7 @@ bool VLightCurveData::fillTeVEvndispData( string iAnaSumFile, double iThresholdS
 {
 	fDataFileName = iAnaSumFile;
 	
-	VFluxCalculation fFluxCalculation( fDataFileName, 1, 0, 100000, fMJD_min, fMJD_max, false );
+	VFluxCalculation fFluxCalculation( fDataFileName, 1, 0, 1000000, fMJD_min, fMJD_max, false );
 	if( fFluxCalculation.IsZombie() )
 	{
 		cout << "VLightCurveData::fill error reading anasum file: " << fDataFileName << endl;

--- a/src/VTS.getRun_TimeElevAzim.cpp
+++ b/src/VTS.getRun_TimeElevAzim.cpp
@@ -143,7 +143,7 @@ int main( int argc, char* argv[] )
 				}
 				else
 				{
-					cout << "Error, '" << file_line << "' needs to be a valid runnumber (9999-99999)" << endl;
+					cout << "Error, '" << file_line << "' needs to be a valid runnumber (9999-999999)" << endl;
 					return 1 ;
 				}
 			}


### PR DESCRIPTION
Requires a couple of changes:

- introduced numerical sorting of runlist in anasum merging step
- changed limits to max run numbers from 100000 to 1000000 (let's see if we reach this in a couple of years)

