### PR TITLE
v490 - alpha.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
   # Triggers the workflow on push or pull request
   # events but only for the main branch
   push:
-    branches: [main, master, v490-dev-v0.2]
+    branches: [main, master, v490-dev-v0.3]
   pull_request:
-    branches: [main, master, v490-dev-v0.2]
+    branches: [main, master, v490-dev-v0.3]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ message: If you use this software, please cite it using these metadata.
 title: "Eventdisplay: an Analysis and Reconstruction Package for VERITAS"
 # doi: 10.5281/zenodo.3559075
 version: 4.9.0-alpha.2
-date-released: 2022-06-15
+date-released: 2022-07-15
 keywords:
 - "gamma-ray astronomy"
 - "astronomy software"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
 title: "Eventdisplay: an Analysis and Reconstruction Package for VERITAS"
 # doi: 10.5281/zenodo.3559075
-version: 4.9.0
+version: 4.9.0-alpha.2
 date-released: 2022-06-15
 keywords:
 - "gamma-ray astronomy"

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ all VTS:	evndisp \
 	VTS.getRun_TimeElevAzim \
 	writeParticleRateFilesForTMVA \
 	writelaserinDB \
-	logFile
+	logFile \
+	printMJD
 
 ###############################################################################################################################
 # core eventdisplay package
@@ -277,6 +278,7 @@ EVNOBJECTS =    ./obj/VVirtualDataReader.o \
 		./obj/VDeadTime.o \
 		./obj/VEventLoop.o \
 		./obj/VDBRunInfo.o \
+		./obj/VSQLTextFileReader.o \
 		./obj/VMonteCarloRunHeader.o ./obj/VMonteCarloRunHeader_Dict.o \
 		./obj/VUtilities.o \
 		./obj/VAstronometry.o ./obj/VAstronometry_Dict.o \
@@ -872,6 +874,21 @@ compareDatawithMC:	$(COMPAREDATAMCOBJ)
 	@echo "$@ done"
 
 ########################################################
+# printMJD 
+########################################################
+PRINTMJDOBJ=		./obj/VSkyCoordinatesUtilities.o \
+					./obj/VAstronometry.o \
+					./obj/VGlobalRunParameter.o ./obj/VGlobalRunParameter_Dict.o \
+					./obj/printMJD.o
+
+./obj/printMJD.o:	./src/printMJD.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+printMJD:	$(PRINTMJDOBJ)
+	$(LD) $(LDFLAGS) $^ $(GLIBS) $(OutPutOpt) ./bin/$@
+	@echo "$@ done"
+
+########################################################
 # printBinaryOrbitalPhase
 ########################################################
 PRINTBINARYOBJ=		./obj/VAstronometry.o ./obj/printBinaryOrbitalPhase.o
@@ -1282,6 +1299,7 @@ VTS.calculateExposureFromDB:	./obj/VDBTools.o ./obj/VDBTools_Dict.o \
 VTSLASERUNOBJ=	./obj/VDBTools.o ./obj/VDBTools_Dict.o \
 			./obj/VStarCatalogue.o ./obj/VStarCatalogue_Dict.o \
 			./obj/VStar.o ./obj/VStar_Dict.o \
+			./obj/VSQLTextFileReader.o \
                         ./obj/VUtilities.o \
                         ./obj/VAstronometry.o ./obj/VAstronometry_Dict.o \
                         ./obj/VSkyCoordinatesUtilities.o \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Eventdisplay - An Analysis and Reconstruction Package for VERITAS
 
+[![DOI](https://zenodo.org/badge/221041866.svg)](https://zenodo.org/badge/latestdoi/221041866)
 [![CI](https://github.com/VERITAS-Observatory/EventDisplay_v4/actions/workflows/ci.yml/badge.svg)](https://github.com/VERITAS-Observatory/EventDisplay_v4/actions/workflows/ci.yml)
+
 * Authors and contributors: [CITATION.cff](CITATION.cff)
 * Licence: [LICENSE](LICENSE)
 

--- a/inc/VCalibrator.h
+++ b/inc/VCalibrator.h
@@ -6,6 +6,7 @@
 #include <VImageBaseAnalyzer.h>
 #include <VPedestalCalculator.h>
 #include <VDB_CalibrationInfo.h>
+#include <VSQLTextFileReader.h>
 
 #include "TClonesArray.h"
 #include "TFile.h"
@@ -98,6 +99,7 @@ class VCalibrator : public VImageBaseAnalyzer
 		string getCalibrationFileName( int iTel, int irun, string iSuffix, string name = "" );
 		void readCalibrationData();
 		bool readCalibrationDatafromDSTFiles( string iSourceFile );
+		void readfromVOFFLINE_DBText( int gain_or_toff, vector< unsigned int >& VchannelList, vector< double >& Vmean, vector< double >& Vrms );
 		void readfromVOFFLINE_DB( int gain_or_toff, string& iFile, vector< unsigned int >& VchannelList, vector< double >& Vmean, vector< double >& Vrms );
 		void readGains( bool iLowGain = false );
 		bool readIPRGraph_from_DSTFile( string iDSTFile, unsigned int iSummationWindow, ULong64_t iTelType );

--- a/inc/VCameraRead.h
+++ b/inc/VCameraRead.h
@@ -20,6 +20,7 @@
 
 #include "VGlobalRunParameter.h"
 #include "VDB_Connection.h"
+#include "VSQLTextFileReader.h"
 
 using namespace std;
 
@@ -93,6 +94,8 @@ class VCameraRead : public VGlobalRunParameter
 		void                 cleanNeighbourList();
 		void                 convertMMtoDeg();    //!< convert camera vectors from mm to deg
 		void                 fillTelescopeVectors();
+		bool                 read_camerarotation_fromDB( string iDBStartTime );
+		bool                 read_camerarotation_fromDBTextFile( unsigned int iRunNumber, string iDBTextDirectory );
 		void                 readPixelFile( string );
 		void                 resetCamVectors( bool bMaxN = true );
 		void                 resetNeighbourLists( bool bMaxN = true );
@@ -353,7 +356,11 @@ class VCameraRead : public VGlobalRunParameter
 		//!< read in camera geometry
 		bool                 readCameraFile( string, unsigned int );
 		//!< read telescope geometry from grisu cfg file
-		bool                 readDetectorGeometryFromDB( string iDBStartTime, bool iReadRotationsFromDB = true );
+		bool                 readDetectorGeometryFromDB(
+			string iDBStartTime,
+			string iDBTextDirectory,
+			unsigned int iRunNumber,
+			bool iReadRotationsFromDB = true );
 		bool                 readGrisucfg( string iFile, unsigned int fNTel );
 		void                 setCameraCentreTubeIndex();
 		void                 setConfigDir( string iDir )

--- a/inc/VDBRunInfo.h
+++ b/inc/VDBRunInfo.h
@@ -21,6 +21,7 @@
 
 #include "VDB_Connection.h"
 #include "VSkyCoordinatesUtilities.h"
+#include "VSQLTextFileReader.h"
 
 using namespace std;
 
@@ -29,6 +30,10 @@ class VDBRunInfo
 	private:
 	
 		bool fDBStatus;
+		string fDBServer;
+		string fDBTextDirectory;
+		
+		unsigned int fNTel;
 		
 		int fRunNumber;
 		int fDBDate;
@@ -54,14 +59,33 @@ class VDBRunInfo
 		string fWeather;
 		vector< unsigned int > fLaserRunID;
 		
-		vector< unsigned int > getLaserRun( string iDBserver, unsigned int iRunNumber, unsigned int iNTel );
-		void                   readRunInfoFromDB( string iDBserver );
-		unsigned int           readRunDQM( string iDBserver, int run_number , unsigned int config_mask );
-		void                   readRunDQM( string iDBserver );
+		int get_time_ymd( string iTemp );
+		double get_time_MJD( string iTemp );
+		int get_time_HMS( string iTemp );
+		int get_time_seconds_of_date( string iTemp );
+		int get_duration( string iTemp );
+		int get_duration_from_sql_string();
+		string get_time_sql( string iTemp );
+		double get_wobble_north( string dist, string angle );
+		double get_wobble_east( string dist, string angle );
+		unsigned int get_dqm_configmask( unsigned int config_mask, unsigned int ConfigMaskDQM );
+		void set_laser_run( vector< unsigned int > iLaserList, vector< unsigned int > iLaserExclude, vector< unsigned int > iLaserConfigMask );
+		void set_telescope_to_analyse();
+		
+		vector< unsigned int > readLaserRun();
+		void                   readRunInfoFromDB();
+		unsigned int           readRunDQM( int run_number, unsigned int config_mask );
+		void                   readRunDQM();
+		
+		vector< unsigned int > readLaserFromDBTextFile();
+		bool readRunInfoFromDBTextFile();
+		void readRunDQMFromDBTextFile();
+		unsigned int readRunDQMFromDBTextFile( int run_number, unsigned int config_mask );
+		bool readTargetFromDBTextFile();
 		
 	public:
 	
-		VDBRunInfo( int irun, string iDBserver, unsigned int iNTel );
+		VDBRunInfo( int irun, string iDBserver, unsigned int iNTel, string iDBTextDirectory = "" );
 		~VDBRunInfo() {}
 		
 		int    getRunDate()

--- a/inc/VDB_PixelDataReader.h
+++ b/inc/VDB_PixelDataReader.h
@@ -18,6 +18,7 @@
 
 #include "VDB_Connection.h"
 #include "VSkyCoordinatesUtilities.h"
+#include "VSQLTextFileReader.h"
 
 using namespace std;
 
@@ -142,6 +143,7 @@ class VDB_PixelDataReader
 		void   print();
 		void   print( string iDatatype, unsigned int iTelID, unsigned int iPixel );
 		bool   readFromDB( string DBServer, unsigned int runNumber, string iDBStartTimeSQL, string fDBRunStoppTimeSQL );
+		bool   readFromDBTextFiles( string iDBTextDirectory, unsigned int runNumber, string iDBStartTimeSQL );
 		void   setDebug( bool iB = false )
 		{
 			fDebug = iB;

--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -104,21 +104,23 @@ class VDispAnalyzer
 									  vector< float > x, vector< float > y,
 									  vector< float > cosphi, vector< float > sinphi,
 									  vector< float > v_disp, vector< float > v_weight,
+									  vector< float > tel_pointing_dx,
+									  vector< float > tel_pointing_dy,
 									  float& dispdiff,
 									  float x_off4 = -999., float yoff_4 = -999. );
 									  
-									  
-		void calculateMeanDirection( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
-									 ULong64_t* iTelType,
-									 double* img_size, double* img_cen_x, double* img_cen_y,
-									 double* img_cosphi, double* img_sinphi,
-									 double* img_width, double* img_length, double* img_asym,
-									 double* img_tgrad, double* img_loss, int* img_ntubes,
-									 double* img_weight,
-									 double xoff_4, double yoff_4,
-									 vector< float > dispErrorT,
-									 float* img_pedvar );
-									 
+		void calculateMeanDispDirection( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
+										 ULong64_t* iTelType,
+										 double* img_size, double* img_cen_x, double* img_cen_y,
+										 double* img_cosphi, double* img_sinphi,
+										 double* img_width, double* img_length, double* img_asym,
+										 double* img_tgrad, double* img_loss, int* img_ntubes,
+										 double* img_weight,
+										 double xoff_4, double yoff_4,
+										 vector< float > dispErrorT,
+										 float* img_pedvar,
+										 double* pointing_dx, double* pointing_dy );
+										 
 		void calculateExpectedDirectionError( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
 											  ULong64_t* iTelType,
 											  double* img_size, double* img_cen_x, double* img_cen_y,

--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -137,6 +137,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		bool fNoCalibNoPb;                        // if true, when no information for gain and toff can be found, the analysis is done filling thenm with 1 and 0 respectively (in VCalibrator)
 		bool fNextDayGainHack;			  //if true, and > 100 channels in one telescope have gain=0, all gains in that tel will be set to 1; gains won't be tested in the dead channel finder.
 		bool fWriteExtraCalibTree;		  // write additional tree into .gain.root file with channel charges/monitor charge/nHiLo for each event
+		bool fWriteImagePixelList;        // write image pixel list to tpars tree
 		string fLowGainCalibrationFile;           // file with file name for low-gain calibration
 		int fNCalibrationEvents;                  // events to be used for calibration
 		float faverageTZeroFiducialRadius;        // fiducial radius for average tzero calculation (DST), in fraction of FOV
@@ -320,6 +321,6 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 			return fuseDB;
 		}
 		
-		ClassDef( VEvndispRunParameter, 2001 ); //(increase this number)
+		ClassDef( VEvndispRunParameter, 2002 ); //(increase this number)
 };
 #endif

--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -52,6 +52,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		
 		// DB parameters
 		bool   fuseDB;
+		string fDBTextDirectory;
 		string fDBRunType;                        // run type according to DB
 		string fDBRunStartTimeSQL;                // run start (SQL type)
 		string fDBRunStoppTimeSQL;                // run stopp (SQL type)
@@ -120,7 +121,6 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		double fazimuth;                          // azimuth in [deg] (preli)
 		bool fDBTracking;                         // use tracking from DB
 		string fDBTrackingCorrections;            // apply tracking corrections from this period (SQL time string), empty for use of measured values in db
-		string fPMTextFileDirectory;              // pointing monitor text file directory
 		bool fDBVPM;                              // use calibrated VPM tracking from database
 		bool fDBUncalibratedVPM;                  // use uncalibrated VPM tracking from database
 		vector<double> fPointingErrorX;           // pointing error, in camera coordinates [deg]
@@ -307,6 +307,10 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 			return fperformFADCAnalysis;
 		}
 		unsigned int getAtmosphereID( bool iUpdateInstrumentEpoch = false );
+		string       getDBTextDirectory()
+		{
+			return fDBTextDirectory;
+		}
 		string       getInstrumentEpoch( bool iMajor = false,
 										 bool iUpdateInstrumentEpoch = false );
 		bool         isMC()
@@ -320,7 +324,11 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		{
 			return fuseDB;
 		}
+		bool         useDBTextFiles()
+		{
+			return ( fDBTextDirectory.size() > 0 );
+		}
 		
-		ClassDef( VEvndispRunParameter, 2002 ); //(increase this number)
+		ClassDef( VEvndispRunParameter, 2003 ); //(increase this number)
 };
 #endif

--- a/inc/VImageAnalyzerData.h
+++ b/inc/VImageAnalyzerData.h
@@ -81,19 +81,19 @@ class VImageAnalyzerData
 		vector<bool> fImage;
 		vector<int> fImageUser;                   //!< channels which are enabled/disables by the user
 		vector<bool> fBorder;
-		vector<bool> fTrigger;                    //!< MS: pixels selected by trigger algorithm
+		vector<bool> fTrigger;                    //!< pixels selected by trigger algorithm
 		vector<bool> fBrightNonImage;             //!< pixel above non image threshold
 		vector<bool> fImageBorderNeighbour;       //!< image and border pixel plus their neighbours
 		// time cleaning
-		vector<int> fClusterNpix;                 //!< HP: numer of pixels in cluster
-		vector<int> fClusterID;                   //!< HP: cluster ID
-		int fMainClusterID;                       //!< HP: main cluster ID
-		vector<double> fClusterSize;              //!< HP: size of the cluster
-		vector<double> fClusterTime;              //!< HP: weighted mean time of the cluster
-		vector<double> fClusterCenx;              //!< HP: cenX of the cluster
-		vector<double> fClusterCeny;              //!< HP: cenY of the cluster
-		int fncluster_cleaned;                    //!< HP: number of clusters
-		int fncluster_uncleaned;                  //!< HP: number of clusters before cluster rejection
+		vector<int> fClusterNpix;                 //!< number of pixels in cluster
+		vector<int> fClusterID;                   //!< cluster ID
+		int fMainClusterID;                       //!< main cluster ID
+		vector<double> fClusterSize;              //!< size of the cluster
+		vector<double> fClusterTime;              //!< weighted mean time of the cluster
+		vector<double> fClusterCenx;              //!< cenX of the cluster
+		vector<double> fClusterCeny;              //!< cenY of the cluster
+		int fncluster_cleaned;                    //!< number of clusters
+		int fncluster_uncleaned;                  //!< number of clusters before cluster rejection
 		// correlation cleaning
 		vector<double> fCorrelationCoefficient;  // correlation coefficient
 		// time since run start
@@ -119,7 +119,7 @@ class VImageAnalyzerData
 		vector< unsigned int > iDummyVectorUI;
 		
 		VImageAnalyzerData( unsigned int iTelID, unsigned int iShortTree = 0,
-							bool bCalibration = false );
+							bool bCalibration = false, bool bWriteImagePixelList = false );
 		~VImageAnalyzerData() {}
 		
 		void                     fillPulseSum( unsigned int, double, bool );

--- a/inc/VImageParameter.h
+++ b/inc/VImageParameter.h
@@ -7,6 +7,8 @@
 
 #include <iostream>
 
+#include "VGlobalRunParameter.h"
+
 using namespace std;
 
 class VImageParameter
@@ -15,6 +17,7 @@ class VImageParameter
 		TTree* tpars;
 		bool fMC;
 		unsigned int fShortTree;                 // if set, only a subset of the parameters are written to the tree of parameters
+		bool fWriteNImagePixels;
 		
 	public:
 		// global parameters
@@ -159,10 +162,17 @@ class VImageParameter
 		float signal;
 		float dsignal;                            //!< error in signal (normalisation parameter for fit)
 		
+		// image / border list
+		unsigned int PixelListN;
+		unsigned int PixelID[VDST_MAXCHANNELS];
+		unsigned int PixelType[VDST_MAXCHANNELS];
+		float PixelIntensity[VDST_MAXCHANNELS];
+		float PixelTimingT0[VDST_MAXCHANNELS];
+		
 		vector< float > fImageBorderPixelPosition_x;              //! list of image+border pixel
 		vector< float > fImageBorderPixelPosition_y;              //! list of image+border pixel
 		
-		VImageParameter( unsigned int iShortTree = 0 );
+		VImageParameter( unsigned int iShortTree = 0, bool iWriteNImagePixels = false );
 		~VImageParameter();
 		void fill();
 		TTree* getTree()
@@ -174,6 +184,10 @@ class VImageParameter
 		bool isMC()
 		{
 			return fMC;
+		}
+		bool isWriteNImagePixels()
+		{
+			return fWriteNImagePixels;
 		}
 		void printParameters();
 		void reset( unsigned int resetLevel = 0 );

--- a/inc/VImageParameterCalculation.h
+++ b/inc/VImageParameterCalculation.h
@@ -76,8 +76,6 @@ class VImageParameterCalculation : public TObject
 		
 		//Hough transform
 		void houghInitialization(); 				//Initialize the Hough transform class
-		void houghMuonRingFinder();                 //!< fit a single ring to the image to look for muons
-		void houghSizeInMuonRing();                 //! calculate the brightness of the muon ring
 		void houghMuonPixelDistribution();          //!< determine the distribution of pixels in the image
 		
 		void calcTriggerParameters( vector<bool> fTrigger );                                   //!< MS: calculate trigger-level image parameters
@@ -124,6 +122,8 @@ class VImageParameterCalculation : public TObject
 		{
 			return fDetectorGeometry;
 		}
+		//!< fill image/border list (optional)
+		void fillImageBorderPixelTree();
 		//!< return value of 2d-gaus at channel iChannel
 		double getFitValue( unsigned int iChannel, double, double, double, double, double, double );
 		//!< set the detector geometry

--- a/inc/VPointing.h
+++ b/inc/VPointing.h
@@ -66,7 +66,10 @@ class VPointing : public VSkyCoordinates
 		{
 			return fPointingType;
 		}
-		void         getPointingFromDB( int irun, string iTCorrections, string iVPMDirectory, bool iVPMDB, bool iUncalibratedVPM );
+		void         getPointingFromDB(
+			int irun, string iTCorrections,
+			bool iVPMDB, bool iUncalibratedVPM,
+			string iDBTextDirectory );
 		unsigned int getTelID()
 		{
 			return fTelID;

--- a/inc/VPointingCorrectionsTreeReader.h
+++ b/inc/VPointingCorrectionsTreeReader.h
@@ -31,6 +31,15 @@ class VPointingCorrectionsTreeReader
 		float getCorrected_cen_x( float cen_x );
 		float getCorrected_cen_y( float cen_y );
 		float getCorrected_phi( float cen_x, float cen_y, float d, float s, float sdevxy );
+		float getPointErrorX()
+		{
+			return fPointingErrorX;
+		}
+		float getPointErrorY()
+		{
+			return fPointingErrorY;
+		}
+		
 		
 };
 

--- a/inc/VPointingDB.h
+++ b/inc/VPointingDB.h
@@ -8,6 +8,7 @@
 #include "VGlobalRunParameter.h"
 #include "VTrackingCorrections.h"
 #include "VDB_Connection.h"
+#include "VSQLTextFileReader.h"
 
 #include <TMath.h>
 #include <TSQLResult.h>
@@ -83,13 +84,18 @@ class VPointingDB : public VGlobalRunParameter
 		VTrackingCorrections* fTrackingCorrections;
 		string fTPointCorrectionDate;
 		
+		bool check_maskVPM( int maskVPM );
 		bool getDBRunInfo();
+		bool getDBTextRunInfo( string iDBTextDirectory );
 		void getDBMJDTime( string itemp, int& MJD, double& Time, bool bStrip );
 		void getDBSourceCoordinates( string iSource, float& iEVNTargetDec, float& iEVNTargetRA );
 		bool readPointingFromDB();
+		bool readPointingFromDBText( string iDBTextDirectory );
 		bool readPointingCalibratedVPMFromDB();
+		bool readPointingCalibratedVPMFromDBTextFile( string iDBTextDirectory );
 		bool readPointingUncalibratedVPMFromDB();
-		bool readPointingFromVPMTextFile( string );
+		void readTrackingCorrections( string iTPointCorrection );
+		void setup_DB_connection();
 		
 		void delete_myconnection()
 		{
@@ -107,8 +113,6 @@ class VPointingDB : public VGlobalRunParameter
 		{
 			delete_myconnection();
 		}
-		
-		
 		bool   isGood()
 		{
 			return fStatus;
@@ -158,7 +162,11 @@ class VPointingDB : public VGlobalRunParameter
 		{
 			return fTelID;
 		}
-		bool   initialize( string iTPointCorrection, string iVPMDirectory, bool iVPMDB, bool iUncalibratedVPM );
+		bool   initialize(
+			string iTPointCorrection,
+			bool iVPMDB,
+			bool iUncalibratedVPM,
+			string iDBTextDirectory );
 		void   setObservatory( double iLongitude_deg = 0., double iLatitude_deg = 0. );
 		bool   terminate();
 		bool   updatePointing( int MJD, double iTime );

--- a/inc/VReadRunParameter.h
+++ b/inc/VReadRunParameter.h
@@ -46,6 +46,7 @@ class VReadRunParameter
 		void isCompiledWithDB();
 		bool getRunParametersFromDST();
 		bool readEpochsAndAtmospheres();
+		void read_db_runinfo();
 		bool readTraceAmplitudeCorrections( string ifile );
 		void setDirectories();
 		

--- a/inc/VSQLTextFileReader.h
+++ b/inc/VSQLTextFileReader.h
@@ -1,0 +1,48 @@
+//! VSQLTextFileReader read sql prepared text file into a map
+
+#ifndef VSQLTextFileReader_H
+#define VSQLTextFileReader_H
+
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+class VSQLTextFileReader
+{
+	private:
+	
+		bool fIsGood;
+		map<string, vector< string >> fData;
+		
+		void readSQLFile( string iSQLFile );
+		
+	public:
+	
+		VSQLTextFileReader( string iSQLFile );
+		VSQLTextFileReader(
+			string iSQLFileDirectory,
+			unsigned irunnumber,
+			string iSQLFileType,
+			unsigned int iTelID = 9999 );
+		~VSQLTextFileReader() {}
+		
+		string getValue_from_key( string iKey );
+		vector< string > getValueVector_from_key( string iKey );
+		vector< unsigned int > getValueVector_from_key_as_integer( string iKey );
+		vector< double > getValueVector_from_key_as_double( string iKey );
+		string getValue_from_key( string iKey, string iSearchKey, string iValue );
+		
+		bool checkDataVectorsForSameLength();
+		bool isGood()
+		{
+			return fIsGood;
+		}
+		void printData();
+};
+
+#endif

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -262,6 +262,8 @@ class VTableLookupDataHandler
 		double ftgrad_x  [VDST_MAXTELESCOPES];
 		double ftchisq_x [VDST_MAXTELESCOPES];
 		double fweight   [VDST_MAXTELESCOPES];    //!< always 1.
+		double fpointing_dx[VDST_MAXTELESCOPES];
+		double fpointing_dy[VDST_MAXTELESCOPES];
 		int    fFitstat  [VDST_MAXTELESCOPES];
 		// {-1}
 		double fR        [VDST_MAXTELESCOPES];    //!< distance from each telescope to reconstructed shower core

--- a/src/VCameraRead.cpp
+++ b/src/VCameraRead.cpp
@@ -1414,12 +1414,94 @@ vector<ULong64_t> VCameraRead::getTelType_list()
 	return t;
 }
 
+bool VCameraRead::read_camerarotation_fromDB( string iDBStartTime )
+{
+	stringstream iTempS;
+	iTempS << getDBServer() << "/VOFFLINE";
+	char c_query[800];
+	sprintf( c_query, "select telescope_id, version, pmt_rotation from tblPointing_Monitor_Camera_Parameters where start_date <= \"%s\" AND end_date > \"%s\" ", iDBStartTime.substr( 0, 10 ).c_str(), iDBStartTime.substr( 0, 10 ).c_str() );
+	
+	VDB_Connection my_connection( iTempS.str().c_str() , "readonly", "" ) ;
+	if( !my_connection.Get_Connection_Status() )
+	{
+		cout << "VCameraRead: failed to connect to database server" << endl;
+		cout << "\t server: " <<  iTempS.str() << endl;
+		return false;
+	}
+	if( !my_connection.make_query( c_query ) )
+	{
+		return false;
+	}
+	TSQLResult* db_res = my_connection.Get_QueryResult();
+	
+	int iNRows = db_res->GetRowCount();
+	vector< int > iVersion( fCameraRotation.size(), -99 );
+	for( int j = 0; j < iNRows; j++ )
+	{
+		TSQLRow* db_row = db_res->Next();
+		if( !db_row )
+		{
+			continue;
+		}
+		
+		int itelID = -99;
+		double iRot = -99.;
+		if( db_row->GetField( 0 ) )
+		{
+			itelID = atoi( db_row->GetField( 0 ) );
+		}
+		// check entry version
+		if( itelID >= 0 && itelID < ( int )iVersion.size() )
+		{
+			if( db_row->GetField( 1 ) && atoi( db_row->GetField( 1 ) ) > iVersion[itelID] )
+			{
+				if( db_row->GetField( 2 ) )
+				{
+					iRot = atof( db_row->GetField( 2 ) ) * TMath::RadToDeg();
+					if( itelID >= 0 && itelID < ( int )fCameraRotation.size() )
+					{
+						fCameraRotation[itelID] = -1.* iRot;
+					}
+				}
+				iVersion[itelID] = atoi( db_row->GetField( 1 ) );
+			}
+		}
+	}
+	return true;
+}
+
+/*
+ * read camera rotation values from text files
+ *
+ */
+bool VCameraRead::read_camerarotation_fromDBTextFile( unsigned int run_number, string iDBTextDirectory )
+{
+	VSQLTextFileReader a( iDBTextDirectory, run_number, "camerarotation" );
+	if( !a.isGood() )
+	{
+		return false;
+	}
+	for( unsigned int telID = 0; telID < fNTel; telID++ )
+	{
+		if( telID < fCameraRotation.size() )
+		{
+			fCameraRotation[telID] = -1. * atof(
+										 a.getValue_from_key( "pmt_rotation", "telescope_id", to_string( telID ) ).c_str() ) * TMath::RadToDeg();
+		}
+	}
+	return true;
+}
+
 /*!
 
      read varios detector parameters from the DB
 
 */
-bool VCameraRead::readDetectorGeometryFromDB( string iDBStartTime, bool iReadRotationsFromDB )
+bool VCameraRead::readDetectorGeometryFromDB(
+	string iDBStartTime,
+	string iDBTextDirectory,
+	unsigned int iRunNumber,
+	bool iReadRotationsFromDB )
 {
 	if( fDebug )
 	{
@@ -1441,60 +1523,20 @@ bool VCameraRead::readDetectorGeometryFromDB( string iDBStartTime, bool iReadRot
 	// read camera rotations from DB
 	if( iReadRotationsFromDB )
 	{
-		stringstream iTempS;
-		iTempS << getDBServer() << "/VOFFLINE";
-		char c_query[800];
-		sprintf( c_query, "select telescope_id, version, pmt_rotation from tblPointing_Monitor_Camera_Parameters where start_date <= \"%s\" AND end_date > \"%s\" ", iDBStartTime.substr( 0, 10 ).c_str(), iDBStartTime.substr( 0, 10 ).c_str() );
-		
-		//std::cout<<"VCameraRead::readDetectorGeometryFromDB "<<std::endl;
-		VDB_Connection my_connection( iTempS.str().c_str() , "readonly", "" ) ;
-		if( !my_connection.Get_Connection_Status() )
+		if( iDBTextDirectory.size() == 0 )
 		{
-			cout << "VCameraRead: failed to connect to database server" << endl;
-			cout << "\t server: " <<  iTempS.str() << endl;
-			return false;
-		}
-		if( !my_connection.make_query( c_query ) )
-		{
-			return false;
-		}
-		TSQLResult* db_res = my_connection.Get_QueryResult();
-		
-		
-		int iNRows = db_res->GetRowCount();
-		vector< int > iVersion( fCameraRotation.size(), -99 );
-		for( int j = 0; j < iNRows; j++ )
-		{
-			TSQLRow* db_row = db_res->Next();
-			if( !db_row )
+			if( !read_camerarotation_fromDB( iDBStartTime ) )
 			{
-				continue;
-			}
-			
-			int itelID = -99;
-			double iRot = -99.;
-			if( db_row->GetField( 0 ) )
-			{
-				itelID = atoi( db_row->GetField( 0 ) );
-			}
-			// check entry version
-			if( itelID >= 0 && itelID < ( int )iVersion.size() )
-			{
-				if( db_row->GetField( 1 ) && atoi( db_row->GetField( 1 ) ) > iVersion[itelID] )
-				{
-					if( db_row->GetField( 2 ) )
-					{
-						iRot = atof( db_row->GetField( 2 ) ) * TMath::RadToDeg();
-						if( itelID >= 0 && itelID < ( int )fCameraRotation.size() )
-						{
-							fCameraRotation[itelID] = -1.* iRot;
-						}
-					}
-					iVersion[itelID] = atoi( db_row->GetField( 1 ) );
-				}
+				return false;
 			}
 		}
-		//       i_DB->Close();
+		else
+		{
+			if( !read_camerarotation_fromDBTextFile( iRunNumber, iDBTextDirectory ) )
+			{
+				return false;
+			}
+		}
 	}
 	
 	cout << "\t (rotations from DB [deg]: ";

--- a/src/VDBRunInfo.cpp
+++ b/src/VDBRunInfo.cpp
@@ -9,19 +9,20 @@
 // irun      : runnumber to pull info for
 // iDBserver : database url to get runinfo from, usually from VGlobalRunParameter->getDBServer()
 // iNTel     : number of telescopes to look for?
-VDBRunInfo::VDBRunInfo( int irun, string iDBserver, unsigned int iNTel )
+VDBRunInfo::VDBRunInfo( int irun, string iDBserver, unsigned int iNTel, string iDBTextDirectory )
 {
 	fRunNumber = irun;
 	fDBStatus = false;
+	fDBServer = iDBserver;
+	fDBTextDirectory = iDBTextDirectory;
 	
-	fTargetName = "";;
+	fNTel = iNTel;
+	fTargetName = "";
 	fTargetDec = -99.;
 	fTargetRA = -99.;
 	fWobbleNorth = 0.;
 	fWobbleEast = 0.;
 	fConfigMask = 0;
-	//fConfigMaskDQM = 0;
-	//fConfigMaskNew = 0;
 	fTelToAna = 1234;
 	fRunType = "";
 	fObservingMode = "";
@@ -37,93 +38,37 @@ VDBRunInfo::VDBRunInfo( int irun, string iDBserver, unsigned int iNTel )
 	fDataStoppTimeMJD = 0.;
 	fDuration = 0;
 	
-	readRunInfoFromDB( iDBserver );
-	readRunDQM( iDBserver );
-	getLaserRun( iDBserver, fRunNumber, iNTel );
+	if( fDBTextDirectory.size() == 0 )
+	{
+		readRunInfoFromDB();
+		readRunDQM();
+		readLaserRun();
+	}
+	else
+	{
+		readRunInfoFromDBTextFile();
+		readTargetFromDBTextFile();
+		readRunDQMFromDBTextFile();
+		readLaserFromDBTextFile();
+	}
 }
 
-void VDBRunInfo::readRunDQM( string iDBserver )
+void VDBRunInfo::readRunDQM()
 {
-
-	int config_mask_new = readRunDQM( iDBserver, fRunNumber, getConfigMask() );
+	int config_mask_new = readRunDQM( fRunNumber, getConfigMask() );
 	fConfigMask = config_mask_new;
-	if( fConfigMask == 1 )
-	{
-		fTelToAna = 1;
-	}
-	else if( fConfigMask == 2 )
-	{
-		fTelToAna = 2;
-	}
-	else if( fConfigMask == 3 )
-	{
-		fTelToAna = 12;
-	}
-	else if( fConfigMask == 4 )
-	{
-		fTelToAna = 3;
-	}
-	else if( fConfigMask == 5 )
-	{
-		fTelToAna = 13;
-	}
-	else if( fConfigMask == 6 )
-	{
-		fTelToAna = 23;
-	}
-	else if( fConfigMask == 7 )
-	{
-		fTelToAna = 123;
-	}
-	else if( fConfigMask == 8 )
-	{
-		fTelToAna = 4;
-	}
-	else if( fConfigMask == 9 )
-	{
-		fTelToAna = 14;
-	}
-	else if( fConfigMask == 10 )
-	{
-		fTelToAna = 24;
-	}
-	else if( fConfigMask == 11 )
-	{
-		fTelToAna = 124;
-	}
-	else if( fConfigMask == 12 )
-	{
-		fTelToAna = 34;
-	}
-	else if( fConfigMask == 13 )
-	{
-		fTelToAna = 134;
-	}
-	else if( fConfigMask == 14 )
-	{
-		fTelToAna = 234;
-	}
-	else if( fConfigMask == 15 )
-	{
-		fTelToAna = 1234;
-	}
-	
-	return;
-	
+	set_telescope_to_analyse();
 }
 
-unsigned int VDBRunInfo::readRunDQM( string iDBserver, int run_number , unsigned int config_mask )
+unsigned int VDBRunInfo::readRunDQM( int run_number, unsigned int config_mask )
 {
-
 	unsigned int ConfigMaskDQM = 0;
-	unsigned int ConfigMaskNew = 0;
 	
 	stringstream iTempS;
-	iTempS << iDBserver << "/VOFFLINE";
+	iTempS << fDBServer << "/VOFFLINE";
 	char c_query[1000];
 	sprintf( c_query, "SELECT run_id , data_category   , status   , status_reason , tel_cut_mask , usable_duration , time_cut_mask , light_level , vpm_config_mask , authors  , comment from tblRun_Analysis_Comments where run_id=%d", run_number );
 	
-	//std::cout<<"VDBRunInfo::readRunDQM "<<std::endl;
 	VDB_Connection my_connection( iTempS.str().c_str(), "readonly", "" ) ;
 	if( !my_connection.Get_Connection_Status() )
 	{
@@ -135,71 +80,61 @@ unsigned int VDBRunInfo::readRunDQM( string iDBserver, int run_number , unsigned
 	}
 	TSQLResult* db_res = my_connection.Get_QueryResult();
 	
-	
 	TSQLRow* db_row = db_res->Next();
 	if( !db_row )
 	{
 		cout << "VDBRunInfo:readRunDQM:Info no row in VOFFLINE DB for run " << run_number << endl;
+		return config_mask;
+	}
+	if( db_row->GetField( 4 ) )
+	{
+		ConfigMaskDQM = ( unsigned int )( atoi( db_row->GetField( 4 ) ) );
 	}
 	else
 	{
-	
-		if( db_row->GetField( 4 ) )
-		{
-			ConfigMaskDQM = ( unsigned int )( atoi( db_row->GetField( 4 ) ) );
-		}
-		else
-		{
-			return config_mask;
-		}
-		
-		// Check if the mask is 0
-		if( ConfigMaskDQM == 0 )
-		{
-			return config_mask;
-		}
-		
-		
-		
-		bitset<4> bitConfig( config_mask );
-		bitset<4> bitDQM( ConfigMaskDQM );
-		bitset<4> bitNDQM;
-		
-		for( int i = 0; i < ( int )bitDQM.size(); i++ )
-		{
-			bitNDQM.set( ( int )bitDQM.size() - i - 1, bitDQM.test( i ) );
-		}
-		
-		bitNDQM = ~bitNDQM;
-		bitset<4> bitNewConfig = bitConfig & bitNDQM;
-		
-		for( int i = 0; i < ( int )bitNewConfig.size(); i++ )
-		{
-			if( bitNewConfig.test( i ) )
-			{
-				ConfigMaskNew += ( unsigned int )pow( 2., i );
-			}
-		}
-		
-		
-		config_mask = ConfigMaskNew;
-		
+		return config_mask;
 	}
 	
-	
-	
-	return config_mask;
-	
+	// Check if the mask is 0
+	if( ConfigMaskDQM == 0 )
+	{
+		return config_mask;
+	}
+	return get_dqm_configmask( config_mask, ConfigMaskDQM );
 }
 
-void VDBRunInfo::readRunInfoFromDB( string iDBserver )
+unsigned int VDBRunInfo::get_dqm_configmask( unsigned int config_mask, unsigned int ConfigMaskDQM )
+{
+	bitset<4> bitConfig( config_mask );
+	bitset<4> bitDQM( ConfigMaskDQM );
+	bitset<4> bitNDQM;
+	
+	for( int i = 0; i < ( int )bitDQM.size(); i++ )
+	{
+		bitNDQM.set( ( int )bitDQM.size() - i - 1, bitDQM.test( i ) );
+	}
+	
+	bitNDQM = ~bitNDQM;
+	bitset<4> bitNewConfig = bitConfig & bitNDQM;
+	unsigned int ConfigMaskNew = 0;
+	
+	for( int i = 0; i < ( int )bitNewConfig.size(); i++ )
+	{
+		if( bitNewConfig.test( i ) )
+		{
+			ConfigMaskNew += ( unsigned int )pow( 2., i );
+		}
+	}
+	return ConfigMaskNew;
+}
+
+void VDBRunInfo::readRunInfoFromDB()
 {
 	stringstream iTempS;
-	iTempS << iDBserver << "/VERITAS";
+	iTempS << fDBServer << "/VERITAS";
 	char c_query[1000];
 	sprintf( c_query, "select * from tblRun_Info where run_id=%d", fRunNumber );
 	
-	//std::cout<<"VDBRunInfo::readRunInfoFromDB "<<std::endl;
 	VDB_Connection my_connection( iTempS.str(), "readonly", "" ) ;
 	if( !my_connection.Get_Connection_Status() )
 	{
@@ -213,7 +148,6 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 	}
 	TSQLResult* db_res = my_connection.Get_QueryResult();
 	
-	
 	TSQLRow* db_row = db_res->Next();
 	if( !db_row )
 	{
@@ -221,16 +155,13 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 		fDBStatus = false;
 		return;
 	}
-	double iStarttime = 0.;
-	double iStopptime = 0.;
-	
 	// get date
 	if( db_row->GetField( 4 ) )
 	{
 		string iTemp = db_row->GetField( 4 );
 		if( iTemp.size() > 8 )
 		{
-			fDBDate = atoi( iTemp.substr( 0, 4 ).c_str() ) * 10000 + atoi( iTemp.substr( 5, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 8, 2 ).c_str() );
+			fDBDate = get_time_ymd( iTemp );
 		}
 		else
 		{
@@ -243,50 +174,26 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 	}
 	if( db_row->GetField( 6 ) )
 	{
-		string iTemp = db_row->GetField( 6 );
-		if( iTemp.size() > 8 )
-		{
-			fDataStartTimeSQL = iTemp;
-			iStarttime = atoi( iTemp.substr( 0, 4 ).c_str() ) * 10000 + atoi( iTemp.substr( 5, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 8, 2 ).c_str() );
-			fDataStartTimeHMS = atoi( iTemp.substr( 11, 2 ).c_str() ) * 10000 + atoi( iTemp.substr( 14, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 17, 2 ).c_str() );
-			fDataStartTime = atoi( iTemp.substr( 11, 2 ).c_str() ) * 60 * 60 + atoi( iTemp.substr( 14, 2 ).c_str() ) * 60 + atoi( iTemp.substr( 17, 2 ).c_str() );
-		}
-		else
-		{
-			iStarttime = 0;
-			fDataStartTime = 0;
-			fDataStartTimeHMS = 0;
-			fDataStartTimeSQL = "";
-		}
+		fDataStartTimeSQL = get_time_sql( db_row->GetField( 6 ) );
+		fDataStartTimeMJD = get_time_MJD( db_row->GetField( 6 ) );
+		fDataStartTimeHMS = get_time_HMS( db_row->GetField( 6 ) );
+		fDataStartTime = get_time_seconds_of_date( db_row->GetField( 6 ) );
 	}
 	else
 	{
-		iStarttime = 0;
 		fDataStartTime = 0;
 		fDataStartTimeHMS = 0;
 		fDataStartTimeSQL = "";
 	}
 	if( db_row->GetField( 7 ) )
 	{
-		string iTemp = db_row->GetField( 7 );
-		if( iTemp.size() > 8 )
-		{
-			fDataStoppTimeSQL = iTemp;
-			iStopptime = atoi( iTemp.substr( 0, 4 ).c_str() ) * 10000 + atoi( iTemp.substr( 5, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 8, 2 ).c_str() );
-			fDataStoppTimeHMS = atoi( iTemp.substr( 11, 2 ).c_str() ) * 10000 + atoi( iTemp.substr( 14, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 17, 2 ).c_str() );
-			fDataStoppTime = atoi( iTemp.substr( 11, 2 ).c_str() ) * 60 * 60 + atoi( iTemp.substr( 14, 2 ).c_str() ) * 60 + atoi( iTemp.substr( 17, 2 ).c_str() );
-		}
-		else
-		{
-			iStopptime = 0;
-			fDataStoppTime = 0.;
-			fDataStoppTimeHMS = 0;
-			fDataStoppTimeSQL = "";
-		}
+		fDataStoppTimeSQL = get_time_sql( db_row->GetField( 7 ) );
+		fDataStoppTimeHMS = get_time_HMS( db_row->GetField( 7 ) );
+		fDataStoppTimeMJD = get_time_MJD( db_row->GetField( 7 ) );
+		fDataStoppTime = get_time_seconds_of_date( db_row->GetField( 7 ) );
 	}
 	else
 	{
-		iStopptime = 0;
 		fDataStoppTime = 0;
 		fDataStoppTimeHMS = 0;
 		fDataStoppTimeSQL = "";
@@ -294,28 +201,15 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 	
 	if( db_row->GetField( 8 ) )
 	{
-		string iTemp = db_row->GetField( 8 );
-		if( iTemp.size() > 7 )
-		{
-			fDuration = atoi( iTemp.substr( 0, 1 ).c_str() ) * 3600 + atoi( iTemp.substr( 3, 4 ).c_str() ) * 60 + atoi( iTemp.substr( 6, 7 ).c_str() );
-		}
-		else
-		{
-			fDuration = 0;
-		}
+		fDuration = get_duration( db_row->GetField( 8 ) );
 	}
 	else
 	{
-		fDuration = 0;
+		fDuration = 0.;
 	}
 	if( TMath::Abs( fDuration < 1.e-4 ) )
 	{
-		double mjd = 0.;
-		double isec_start = 0.;
-		double isec_stopp = 0.;
-		VSkyCoordinatesUtilities::getMJD_from_SQLstring( fDataStartTimeSQL, mjd, isec_start );
-		VSkyCoordinatesUtilities::getMJD_from_SQLstring( fDataStoppTimeSQL, mjd, isec_stopp );
-		fDuration = isec_stopp - isec_start;
+		fDuration = get_duration_from_sql_string();
 	}
 	
 	if( db_row->GetField( 19 ) )
@@ -326,35 +220,6 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 	{
 		fTargetName = "";
 	}
-	
-	double imjd = 0.;
-	int j = 0;
-	int iy = iStarttime / 10000;
-	int im = ( iStarttime - iy * 10000 ) / 100;
-	int id = iStarttime - iy * 10000 - im * 100;
-	if( iStarttime > 0 )
-	{
-		VAstronometry::vlaCldj( iy, im, id, &imjd, &j );
-	}
-	else
-	{
-		imjd = 0.;
-	}
-	fDataStartTimeMJD = imjd;
-	iy = iStopptime / 10000;
-	im = ( iStopptime - iy * 10000 ) / 100;
-	id = iStopptime - iy * 10000 - im * 100;
-	if( iStopptime > 0 )
-	{
-		VAstronometry::vlaCldj( iy, im, id, &imjd, &j );
-	}
-	else
-	{
-		imjd = 0.;
-	}
-	fDataStoppTimeMJD  = imjd;
-	// calculate start and stop time
-	
 	if( db_row->GetField( 1 ) )
 	{
 		fRunType = db_row->GetField( 1 );
@@ -371,26 +236,10 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 	{
 		fWeather = db_row->GetField( 9 );
 	}
-	
-	float dist = 0.;
-	if( db_row->GetField( 17 ) )
+	if( db_row->GetField( 17 ) && db_row->GetField( 18 ) )
 	{
-		dist = atof( db_row->GetField( 17 ) );
-	}
-	float angl = 0.;
-	if( db_row->GetField( 18 ) )
-	{
-		angl = atof( db_row->GetField( 18 ) );
-	}
-	fWobbleNorth = dist * cos( angl * TMath::DegToRad() );
-	fWobbleEast = dist * sin( angl * TMath::DegToRad() );
-	if( TMath::Abs( fWobbleNorth ) < 1.e-15 )
-	{
-		fWobbleNorth = 0.;
-	}
-	if( TMath::Abs( fWobbleEast ) < 1.e-15 )
-	{
-		fWobbleEast = 0.;
+		fWobbleNorth = get_wobble_north( db_row->GetField( 17 ), db_row->GetField( 18 ) );
+		fWobbleEast = get_wobble_east( db_row->GetField( 17 ), db_row->GetField( 18 ) );
 	}
 	
 	// get config mask
@@ -402,66 +251,7 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 	{
 		fConfigMask = 0;
 	}
-	if( fConfigMask == 1 )
-	{
-		fTelToAna = 1;
-	}
-	else if( fConfigMask == 2 )
-	{
-		fTelToAna = 2;
-	}
-	else if( fConfigMask == 3 )
-	{
-		fTelToAna = 12;
-	}
-	else if( fConfigMask == 4 )
-	{
-		fTelToAna = 3;
-	}
-	else if( fConfigMask == 5 )
-	{
-		fTelToAna = 13;
-	}
-	else if( fConfigMask == 6 )
-	{
-		fTelToAna = 23;
-	}
-	else if( fConfigMask == 7 )
-	{
-		fTelToAna = 123;
-	}
-	else if( fConfigMask == 8 )
-	{
-		fTelToAna = 4;
-	}
-	else if( fConfigMask == 9 )
-	{
-		fTelToAna = 14;
-	}
-	else if( fConfigMask == 10 )
-	{
-		fTelToAna = 24;
-	}
-	else if( fConfigMask == 11 )
-	{
-		fTelToAna = 124;
-	}
-	else if( fConfigMask == 12 )
-	{
-		fTelToAna = 34;
-	}
-	else if( fConfigMask == 13 )
-	{
-		fTelToAna = 134;
-	}
-	else if( fConfigMask == 14 )
-	{
-		fTelToAna = 234;
-	}
-	else if( fConfigMask == 15 )
-	{
-		fTelToAna = 1234;
-	}
+	set_telescope_to_analyse();
 	
 	// get source coordinates
 	sprintf( c_query, "select * from tblObserving_Sources where source_id like convert( _utf8 \'%s\' using latin1)", fTargetName.c_str() );
@@ -484,7 +274,6 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 		fTargetRA = atof( db_row->GetField( 1 ) ) * 180. / TMath::Pi();
 	}
 	
-	
 	fDBStatus = true;
 	return;
 }
@@ -492,7 +281,7 @@ void VDBRunInfo::readRunInfoFromDB( string iDBserver )
 
 void VDBRunInfo::print()
 {
-	cout << "Reading run info from database for run " << fRunNumber << ":" << endl;
+	cout << "Run info for run " << fRunNumber << ":" << endl;
 	cout << "Date: " << fDBDate << "(" << fDataStartTimeSQL << "," << fDataStoppTimeSQL << ")";
 	cout << ", Duration: " << fDuration << " [s]";
 	cout << ", " << fRunType << ", " << fObservingMode << ", " << fRunStatus;
@@ -509,13 +298,13 @@ void VDBRunInfo::print()
 }
 
 
-vector< unsigned int > VDBRunInfo::getLaserRun( string iDBserver, unsigned int iRunNumber, unsigned int iNTel )
+vector< unsigned int > VDBRunInfo::readLaserRun()
 {
 	stringstream iTempS;
-	iTempS << iDBserver << "/VERITAS";
+	iTempS << fDBServer << "/VERITAS";
 	char c_query[1000];
 	
-	sprintf( c_query, "SELECT info.run_id, grp_cmt.excluded_telescopes, info.config_mask FROM tblRun_Info AS info, tblRun_Group AS grp, tblRun_GroupComment AS grp_cmt, (SELECT group_id FROM tblRun_Group WHERE run_id=%d) AS run_grp WHERE grp_cmt.group_id = run_grp.group_id AND grp_cmt.group_type='laser' AND grp_cmt.group_id=grp.group_id AND grp.run_id=info.run_id AND (info.run_type='flasher' OR info.run_type='laser')", iRunNumber );
+	sprintf( c_query, "SELECT info.run_id, grp_cmt.excluded_telescopes, info.config_mask FROM tblRun_Info AS info, tblRun_Group AS grp, tblRun_GroupComment AS grp_cmt, (SELECT group_id FROM tblRun_Group WHERE run_id=%d) AS run_grp WHERE grp_cmt.group_id = run_grp.group_id AND grp_cmt.group_type='laser' AND grp_cmt.group_id=grp.group_id AND grp.run_id=info.run_id AND (info.run_type='flasher' OR info.run_type='laser')", fRunNumber );
 	
 	//std::cout<<"VDBRunInfo::getLaserRun "<<std::endl;
 	VDB_Connection my_connection( iTempS.str(), "readonly", "" ) ;
@@ -549,30 +338,340 @@ vector< unsigned int > VDBRunInfo::getLaserRun( string iDBserver, unsigned int i
 			iLaserExclude.push_back( atoi( db_row->GetField( 1 ) ) );
 			iLaserConfigMask.push_back( atoi( db_row->GetField( 2 ) ) );
 		}
-		
 	}
 	else
 	{
-		cout << "WARNING: VDBRunInfo::getLaserRun() no laser run found for telescope " << iNTel << " and run " << iRunNumber << endl;
+		cout << "WARNING: VDBRunInfo::readLaserRun() no laser run found for telescope " << fNTel << " and run " << fRunNumber << endl;
 	}
 	
-	fLaserRunID.assign( iNTel, 0 );
-	for( unsigned int t = 0; t < iNTel; t++ )
+	set_laser_run( iLaserList, iLaserExclude, iLaserConfigMask );
+	
+	return fLaserRunID;
+}
+
+void VDBRunInfo::set_laser_run(
+	vector< unsigned int > iLaserList,
+	vector< unsigned int > iLaserExclude,
+	vector< unsigned int > iLaserConfigMask )
+{
+	fLaserRunID.assign( fNTel, 0 );
+	for( unsigned int t = 0; t < fNTel; t++ )
 	{
 		// check if this run is excluded from group
 		// also check if telescope is within the config mask (taking DQM cuts into account)
 		for( unsigned int i = 0; i < iLaserList.size(); i++ )
 		{
 			bitset< 8 > ibit( iLaserExclude[i] );
-			unsigned int config_mask = readRunDQM( iDBserver, iLaserList[i], iLaserConfigMask[i] );
+			unsigned int config_mask = 0;
+			if( fDBTextDirectory.size() == 0 )
+			{
+				config_mask = readRunDQM( iLaserList[i], iLaserConfigMask[i] );
+			}
+			else
+			{
+				config_mask = readRunDQMFromDBTextFile( iLaserList[i], iLaserConfigMask[i] );
+			}
 			bitset< 8 > ibit_mask( config_mask );
 			if( !ibit.test( t ) && ibit_mask.test( t ) )
 			{
 				fLaserRunID[t] = iLaserList[i];
 			}
-			
 		}
 	}
+}
+
+int VDBRunInfo::get_time_ymd( string iTemp )
+{
+	return atoi( iTemp.substr( 0, 4 ).c_str() ) * 10000
+		   + atoi( iTemp.substr( 5, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 8, 2 ).c_str() );
+}
+
+double VDBRunInfo::get_time_MJD( string iTemp )
+{
+	if( iTemp.size() < 9 )
+	{
+		return 0.;
+	}
+	int iTime = get_time_ymd( iTemp );
+	if( iTime <= 0 )
+	{
+		return 0.;
+	}
+	double imjd = 0.;
+	int j = 0;
+	int iy = iTime / 10000;
+	int im = ( iTime - iy * 10000 ) / 100;
+	int id = iTime - iy * 10000 - im * 100;
+	if( iTime > 0 )
+	{
+		VAstronometry::vlaCldj( iy, im, id, &imjd, &j );
+	}
+	return imjd;
+}
+
+int VDBRunInfo::get_time_HMS( string iTemp )
+{
+	if( iTemp.size() < 9 )
+	{
+		return 0.;
+	}
+	return atoi( iTemp.substr( 11, 2 ).c_str() ) * 10000
+		   + atoi( iTemp.substr( 14, 2 ).c_str() ) * 100 + atoi( iTemp.substr( 17,  2 ).c_str() );
+}
+
+int VDBRunInfo::get_time_seconds_of_date( string iTemp )
+{
+	if( iTemp.size() < 9 )
+	{
+		return 0.;
+	}
+	return atoi( iTemp.substr( 11, 2 ).c_str() ) * 60 * 60
+		   + atoi( iTemp.substr( 14, 2 ).c_str() ) * 60 + atoi( iTemp.substr( 17, 2 ).c_str() );
+}
+
+int VDBRunInfo::get_duration( string iTemp )
+{
+	if( iTemp.size() < 8 )
+	{
+		return 0.;
+	}
+	return atoi( iTemp.substr( 0, 1 ).c_str() ) * 3600 + atoi( iTemp.substr( 3, 4 ).c_str() ) * 60 + atoi( iTemp.substr( 6, 7 ).c_str() );
+}
+
+int VDBRunInfo::get_duration_from_sql_string()
+{
+	double mjd = 0.;
+	double isec_start = 0.;
+	double isec_stopp = 0.;
+	VSkyCoordinatesUtilities::getMJD_from_SQLstring( fDataStartTimeSQL, mjd, isec_start );
+	VSkyCoordinatesUtilities::getMJD_from_SQLstring( fDataStoppTimeSQL, mjd, isec_stopp );
+	return ( int )( isec_stopp - isec_start );
+}
+
+string VDBRunInfo::get_time_sql( string iTemp )
+{
+	if( iTemp.size() < 9 )
+	{
+		return "";
+	}
+	return iTemp;
+}
+
+double VDBRunInfo::get_wobble_north( string dist, string angle )
+{
+	double w = atof( dist.c_str() ) * cos( atof( angle.c_str() ) * TMath::DegToRad() );
+	if( TMath::Abs( w ) < 1.e-15 )
+	{
+		return 0.;
+	}
+	return w;
+}
+
+double VDBRunInfo::get_wobble_east( string dist, string angle )
+{
+	double w = atof( dist.c_str() ) * sin( atof( angle.c_str() ) * TMath::DegToRad() );
+	if( TMath::Abs( w ) < 1.e-15 )
+	{
+		return 0.;
+	}
+	return w;
+}
+
+void VDBRunInfo::set_telescope_to_analyse()
+{
+	if( fConfigMask == 1 )
+	{
+		fTelToAna = 1;
+	}
+	else if( fConfigMask == 2 )
+	{
+		fTelToAna = 2;
+	}
+	else if( fConfigMask == 3 )
+	{
+		fTelToAna = 12;
+	}
+	else if( fConfigMask == 4 )
+	{
+		fTelToAna = 3;
+	}
+	else if( fConfigMask == 5 )
+	{
+		fTelToAna = 13;
+	}
+	else if( fConfigMask == 6 )
+	{
+		fTelToAna = 23;
+	}
+	else if( fConfigMask == 7 )
+	{
+		fTelToAna = 123;
+	}
+	else if( fConfigMask == 8 )
+	{
+		fTelToAna = 4;
+	}
+	else if( fConfigMask == 9 )
+	{
+		fTelToAna = 14;
+	}
+	else if( fConfigMask == 10 )
+	{
+		fTelToAna = 24;
+	}
+	else if( fConfigMask == 11 )
+	{
+		fTelToAna = 124;
+	}
+	else if( fConfigMask == 12 )
+	{
+		fTelToAna = 34;
+	}
+	else if( fConfigMask == 13 )
+	{
+		fTelToAna = 134;
+	}
+	else if( fConfigMask == 14 )
+	{
+		fTelToAna = 234;
+	}
+	else if( fConfigMask == 15 )
+	{
+		fTelToAna = 1234;
+	}
+}
+
+bool VDBRunInfo::readRunInfoFromDBTextFile()
+{
+	VSQLTextFileReader a( fDBTextDirectory, fRunNumber, "runinfo" );
+	if( !a.isGood() )
+	{
+		return false;
+	}
+	if( a.getValue_from_key( "db_start_time" ).size() > 0 )
+	{
+		fDBDate = get_time_ymd( a.getValue_from_key( "db_start_time" ) );
+	}
+	if( a.getValue_from_key( "data_start_time" ).size() > 0 )
+	{
+		fDataStartTimeSQL = get_time_sql( a.getValue_from_key( "data_start_time" ) );
+		fDataStartTimeMJD = get_time_MJD( a.getValue_from_key( "data_start_time" ) );
+		fDataStartTimeHMS = get_time_HMS( a.getValue_from_key( "data_start_time" ) );
+		fDataStartTime = get_time_seconds_of_date( a.getValue_from_key( "data_start_time" ) );
+	}
+	if( a.getValue_from_key( "data_end_time" ).size() > 0 )
+	{
+		fDataStoppTimeSQL = get_time_sql( a.getValue_from_key( "data_end_time" ) );
+		fDataStoppTimeMJD = get_time_MJD( a.getValue_from_key( "data_end_time" ) );
+		fDataStoppTimeHMS = get_time_HMS( a.getValue_from_key( "data_end_time" ) );
+		fDataStoppTime = get_time_seconds_of_date( a.getValue_from_key( "data_end_time" ) );
+	}
+	if( a.getValue_from_key( "duration" ).size() > 0 )
+	{
+		fDuration  = get_duration( a.getValue_from_key( "duration" ) );
+	}
+	if( TMath::Abs( fDuration < 1.e-4 ) )
+	{
+		fDuration = get_duration_from_sql_string();
+	}
+	if( a.getValue_from_key( "source_id" ).size() > 0 )
+	{
+		fTargetName = a.getValue_from_key( "source_id" );
+	}
+	if( a.getValue_from_key( "run_type" ).size() > 0 )
+	{
+		fRunType = a.getValue_from_key( "run_type" );
+	}
+	if( a.getValue_from_key( "observing_mode" ).size() > 0 )
+	{
+		fObservingMode = a.getValue_from_key( "observing_mode" );
+	}
+	if( a.getValue_from_key( "run_status" ).size() > 0 )
+	{
+		fRunStatus = a.getValue_from_key( "run_status" );
+	}
+	if( a.getValue_from_key( "weather" ).size() > 0 )
+	{
+		fWeather = a.getValue_from_key( "weather" );
+	}
+	if( a.getValue_from_key( "offset_distance" ).size() > 0 && a.getValue_from_key( "offset_angle" ).size() > 0 )
+	{
+		fWobbleNorth = get_wobble_north( a.getValue_from_key( "offset_distance" ), a.getValue_from_key( "offset_angle" ) );
+		fWobbleEast = get_wobble_east( a.getValue_from_key( "offset_distance" ), a.getValue_from_key( "offset_angle" ) );
+	}
+	if( a.getValue_from_key( "config_mask" ).size() > 0 )
+	{
+		fConfigMask = ( unsigned int )( atoi( a.getValue_from_key( "config_mask" ).c_str() ) );
+		set_telescope_to_analyse();
+	}
+	fDBStatus = true;
+	return true;
+}
+
+bool VDBRunInfo::readTargetFromDBTextFile()
+{
+	VSQLTextFileReader a( fDBTextDirectory, fRunNumber, "target" );
+	if( !a.isGood() )
+	{
+		return false;
+	}
+	string i_dec = a.getValue_from_key( "decl", "source_id", fTargetName );
+	string i_ra = a.getValue_from_key( "ra", "source_id", fTargetName );
+	if( i_dec.size() > 0 && i_ra.size() > 0 )
+	{
+		fTargetDec = atof( i_dec.c_str() ) * TMath::RadToDeg();
+		fTargetRA =  atof( i_ra.c_str() ) * TMath::RadToDeg();
+	}
+	else
+	{
+		cout << "Error reading target (" << fTargetName << ") from DB text file" << endl;
+		return false;
+	}
+	
+	return true;
+}
+
+vector< unsigned int > VDBRunInfo::readLaserFromDBTextFile()
+{
+	vector< unsigned int > iTemp;
+	VSQLTextFileReader a( fDBTextDirectory, fRunNumber, "laserrun" );
+	if( !a.isGood() )
+	{
+		return iTemp;
+	}
+	vector< unsigned int > iLaserList = a.getValueVector_from_key_as_integer( "run_id" );
+	vector< unsigned int > iLaserConfigMask = a.getValueVector_from_key_as_integer( "config_mask" );
+	vector< unsigned int > iLaserExclude = a.getValueVector_from_key_as_integer( "excluded_telescopes" );
+	
+	set_laser_run( iLaserList, iLaserExclude, iLaserConfigMask );
 	
 	return fLaserRunID;
+}
+
+void VDBRunInfo::readRunDQMFromDBTextFile()
+{
+	fConfigMask = readRunDQMFromDBTextFile( fRunNumber, getConfigMask() );
+	set_telescope_to_analyse();
+}
+
+
+unsigned int VDBRunInfo::readRunDQMFromDBTextFile( int run_number, unsigned int config_mask )
+{
+	unsigned int ConfigMaskDQM = 0;
+	
+	VSQLTextFileReader a( fDBTextDirectory, fRunNumber, "rundqm" );
+	if( !a.isGood() )
+	{
+		return config_mask;
+	}
+	string i_config_mask = a.getValue_from_key( "tel_cut_mask", "run_id", to_string( run_number ) );
+	if( i_config_mask.size() > 0 && i_config_mask != "NULL" )
+	{
+		ConfigMaskDQM = atoi( i_config_mask.c_str() );
+	}
+	if( ConfigMaskDQM == 0 )
+	{
+		return config_mask;
+	}
+	return get_dqm_configmask( config_mask, ConfigMaskDQM );
 }

--- a/src/VDB_Connection.cpp
+++ b/src/VDB_Connection.cpp
@@ -43,7 +43,6 @@ bool VDB_Connection::Connect()
 
 	// Connect
 	f_db = TSQLServer::Connect( fDBserver.c_str(), fconnection_mode.c_str() , fconnection_option.c_str() );
-	//std::cout<<"VDB_Connection::Connect  server "<<fDBserver<<" mode "<<fconnection_mode<<" option "<<fconnection_option <<std::endl;
 	
 	// Test the connection
 	

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -163,6 +163,7 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 		vector< float > x, vector< float > y,
 		vector< float > cosphi, vector< float > sinphi,
 		vector< float > v_disp, vector< float > v_weight,
+		vector< float > tel_pointing_dx, vector< float > tel_pointing_dy,
 		float& dispdiff,
 		float x_off4, float yoff_4 )
 {
@@ -281,11 +282,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			// image #1
 			if( ii == 0 )
 			{
-				x1 = x[ii] - v_disp[ii] * cosphi[ii];
-				x2 = x[ii] + v_disp[ii] * cosphi[ii];
+				x1 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x2 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y1 = y[ii] - v_disp[ii] * sinphi[ii];
-				y2 = y[ii] + v_disp[ii] * sinphi[ii];
+				y1 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y2 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				fdisp_xs_T[0] = x1;
 				fdisp_ys_T[0] = y1;
@@ -295,11 +296,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			// image #2
 			else if( ii == 1 )
 			{
-				x3 = x[ii] - v_disp[ii] * cosphi[ii];
-				x4 = x[ii] + v_disp[ii] * cosphi[ii];
+				x3 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x4 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y3 = y[ii] - v_disp[ii] * sinphi[ii];
-				y4 = y[ii] + v_disp[ii] * sinphi[ii];
+				y3 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y4 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				if( ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) < ( x1 - x4 ) * ( x1 - x4 ) + ( y1 - y4 ) * ( y1 - y4 )
 						&& ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) < ( x2 - x3 ) * ( x2 - x3 ) + ( y2 - y3 ) * ( y2 - y3 )
@@ -348,11 +349,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			// image #3
 			else if( ii == 2 )
 			{
-				x5 = x[ii] - v_disp[ii] * cosphi[ii];
-				x6 = x[ii] + v_disp[ii] * cosphi[ii];
+				x5 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x6 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y5 = y[ii] - v_disp[ii] * sinphi[ii];
-				y6 = y[ii] + v_disp[ii] * sinphi[ii];
+				y5 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y6 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				if( ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x3 ) * ( x2 - x3 ) + ( y2 - y3 ) * ( y2 - y3 ) + ( x2 - x5 ) * ( x2 - x5 ) + ( y2 - y5 ) * ( y2 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x1 - x4 ) * ( x1 - x4 ) + ( y1 - y4 ) * ( y1 - y4 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x4 - x5 ) * ( x4 - x5 ) + ( y4 - y5 ) * ( y4 - y5 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x4 ) * ( x2 - x4 ) + ( y2 - y4 ) * ( y2 - y4 ) + ( x2 - x5 ) * ( x2 - x5 ) + ( y2 - y5 ) * ( y2 - y5 ) + ( x4 - x5 ) * ( x4 - x5 ) + ( y4 - y5 ) * ( y4 - y5 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x6 ) * ( x1 - x6 ) + ( y1 - y6 ) * ( y1 - y6 ) + ( x3 - x6 ) * ( x3 - x6 ) + ( y3 - y6 ) * ( y3 - y6 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x3 ) * ( x2 - x3 ) + ( y2 - y3 ) * ( y2 - y3 ) + ( x2 - x6 ) * ( x2 - x6 ) + ( y2 - y6 ) * ( y2 - y6 ) + ( x3 - x6 ) * ( x3 - x6 ) + ( y3 - y6 ) * ( y3 - y6 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x1 - x4 ) * ( x1 - x4 ) + ( y1 - y4 ) * ( y1 - y4 ) + ( x1 - x6 ) * ( x1 - x6 ) + ( y1 - y6 ) * ( y1 - y6 ) + ( x4 - x6 ) * ( x4 - x6 ) + ( y4 - y6 ) * ( y4 - y6 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x4 ) * ( x2 - x4 ) + ( y2 - y4 ) * ( y2 - y4 ) + ( x2 - x6 ) * ( x2 - x6 ) + ( y2 - y6 ) * ( y2 - y6 ) + ( x4 - x6 ) * ( x4 - x6 ) + ( y4 - y6 ) * ( y4 - y6 ) )
 				{
@@ -445,11 +446,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			if( ii == 3 )
 			{
 			
-				x3 = x[ii] - v_disp[ii] * cosphi[ii];
-				x4 = x[ii] + v_disp[ii] * cosphi[ii];
+				x3 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x4 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y3 = y[ii] - v_disp[ii] * sinphi[ii];
-				y4 = y[ii] + v_disp[ii] * sinphi[ii];
+				y3 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y4 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				
 				if( ( xs - x3 ) * ( xs - x3 ) + ( ys - y3 ) * ( ys - y3 ) < ( xs - x4 ) * ( xs - x4 ) + ( ys - y4 ) * ( ys - y4 ) )
@@ -487,11 +488,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 		
 		for( unsigned int ii = 0; ii < v_weight.size(); ii++ )
 		{
-			x1 = x[ii] - v_disp[ii] * cosphi[ii];
-			x2 = x[ii] + v_disp[ii] * cosphi[ii];
+			x1 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+			x2 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 			
-			y1 = y[ii] - v_disp[ii] * sinphi[ii];
-			y2 = y[ii] + v_disp[ii] * sinphi[ii];
+			y1 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+			y2 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 			
 			// check solution closest to starting value
 			// (should work properly here, as these are
@@ -584,13 +585,13 @@ void VDispAnalyzer::calculateMeanShowerDirection( vector< float > v_x, vector< f
 }
 
 /*
- * calculate mean direction using as input C arrays
+ * calculate mean disp direction using as input C arrays
  * (used primarily from lookup table code)
  *
  * called from VTableLookupDataHandler::doStereoReconstruction()
  *
  */
-void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
+void VDispAnalyzer::calculateMeanDispDirection( unsigned int i_ntel,
 		float iArrayElevation,
 		float iArrayAzimuth,
 		ULong64_t* iTelType,
@@ -609,7 +610,9 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
 		double xoff_4,
 		double yoff_4,
 		vector< float > dispErrorT,
-		float* img_pedvar )
+		float* img_pedvar,
+		double* pointing_dx,
+		double* pointing_dy )
 {
 	// reset values from previous event
 	f_disp = -99.;
@@ -636,6 +639,8 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
 	vector< float > y;
 	vector< float > cosphi;
 	vector< float > sinphi;
+	vector< float > tel_pointing_dx;
+	vector< float > tel_pointing_dy;
 	
 	//////////////////////////////
 	// loop over all telescopes and calculate disp per telescope
@@ -690,11 +695,16 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
 			y.push_back( img_cen_y[i] );
 			cosphi.push_back( img_cosphi[i] );
 			sinphi.push_back( img_sinphi[i] );
+			tel_pointing_dx.push_back( pointing_dx[i] );
+			tel_pointing_dy.push_back( pointing_dy[i] );
 		}
 	}
 	
 	// calculate expected direction
-	calculateMeanDirection( f_xs, f_ys, x, y, cosphi, sinphi, v_disp, v_weight, f_dispDiff, xoff_4, yoff_4 );
+	calculateMeanDirection( f_xs, f_ys,
+							x, y, cosphi, sinphi, v_disp, v_weight,
+							tel_pointing_dx, tel_pointing_dy,
+							f_dispDiff, xoff_4, yoff_4 );
 	fdisp_xy_weight_T = v_weight;
 	fdisp_T = v_disp;
 	fdisplist_T = v_displist;

--- a/src/VEventLoop.cpp
+++ b/src/VEventLoop.cpp
@@ -438,8 +438,16 @@ bool VEventLoop::initEventLoop( string iFileName )
 	{
 		fDB_PixelDataReader = new VDB_PixelDataReader( getDetectorGeo()->getNumChannelVector() );
 		fDB_PixelDataReader->setDebug( fRunPar->fDebug );
-		fDB_PixelDataReader->readFromDB( fRunPar->getDBServer(), fRunPar->frunnumber,
-										 fRunPar->fDBRunStartTimeSQL, fRunPar->fDBRunStoppTimeSQL );
+		if( fRunPar->useDBTextFiles() )
+		{
+			fDB_PixelDataReader->readFromDBTextFiles(
+				fRunPar->getDBTextDirectory(), fRunPar->frunnumber, fRunPar->fDBRunStartTimeSQL );
+		}
+		else
+		{
+			fDB_PixelDataReader->readFromDB( fRunPar->getDBServer(), fRunPar->frunnumber,
+											 fRunPar->fDBRunStartTimeSQL, fRunPar->fDBRunStoppTimeSQL );
+		}
 	}
 	
 	// set event number vector
@@ -547,8 +555,9 @@ bool VEventLoop::initEventLoop( string iFileName )
 			// set pointing error
 			if( fRunPar->fDBTracking )
 			{
-				fPointing.back()->getPointingFromDB( fRunPar->frunnumber, fRunPar->fDBTrackingCorrections, fRunPar->fPMTextFileDirectory,
-													 fRunPar->fDBVPM, fRunPar->fDBUncalibratedVPM );
+				fPointing.back()->getPointingFromDB( fRunPar->frunnumber, fRunPar->fDBTrackingCorrections,
+													 fRunPar->fDBVPM, fRunPar->fDBUncalibratedVPM,
+													 fRunPar->getDBTextDirectory() );
 			}
 			else
 			{

--- a/src/VEventLoop.cpp
+++ b/src/VEventLoop.cpp
@@ -612,7 +612,8 @@ void VEventLoop::initializeAnalyzers()
 			setTelID( i );
 			fAnaData.push_back( new VImageAnalyzerData( i, fRunPar->fShortTree, ( fRunMode == R_PED || fRunMode == R_PEDLOW ||
 								fRunMode == R_GTO || fRunMode == R_GTOLOW ||
-								fRunMode == R_TZERO || fRunMode == R_TZEROLOW ) ) );
+								fRunMode == R_TZERO || fRunMode == R_TZEROLOW ),
+								getRunParameter()->fWriteImagePixelList ) );
 			int iseed = fRunPar->fMCNdeadSeed;
 			if( iseed != 0 )
 			{

--- a/src/VEvndispData.cpp
+++ b/src/VEvndispData.cpp
@@ -231,7 +231,11 @@ void VEvndispData::setDetectorGeometry( unsigned int iNTel, vector< string > iCa
 		// get camera rotations from the DB
 		if( getRunParameter()->fDBCameraRotationMeasurements )
 		{
-			fDetectorGeo->readDetectorGeometryFromDB( getRunParameter()->fDBRunStartTimeSQL, getRunParameter()->fDBCameraRotationMeasurements );
+			fDetectorGeo->readDetectorGeometryFromDB(
+				getRunParameter()->fDBRunStartTimeSQL,
+				getRunParameter()->getDBTextDirectory(),
+				getRunNumber(),
+				getRunParameter()->fDBCameraRotationMeasurements );
 		}
 	}
 	// for DST files: read detector geometry from DST file

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -230,6 +230,7 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	ffillhistos = false;                          // obsolete
 	foutputfileName = "";
 	fWriteExtraCalibTree = false;
+	fWriteImagePixelList = false;
 	// MC parameters
 	// offset in telescope numbering (0 for old grisudet version (<3.0.0))
 	ftelescopeNOffset = 1;
@@ -730,6 +731,10 @@ void VEvndispRunParameter::print( int iEv )
 	if( fShortTree )
 	{
 		cout << endl << "shortened tree output " << endl;
+	}
+	if( fWriteImagePixelList )
+	{
+		cout << "(add image/border pixel list to output tree)" << endl;
 	}
 	
 	// print analysis parameters

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -33,8 +33,10 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	// run parameters
 #ifdef RUNWITHDB
 	fuseDB = true;
+	fDBTextDirectory = "";
 #else
 	fuseDB = false;
+	fDBTextDirectory = "";
 #endif
 	frunmode = 0;
 	fRunIsZeroSuppressed = false;
@@ -138,7 +140,6 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	fDBUncalibratedVPM = false;
 #endif
 	fDBTrackingCorrections = "";
-	fPMTextFileDirectory = "";
 	fPointingErrorX.push_back( 0. );
 	fPointingErrorY.push_back( 0. );
 	// star catalogue
@@ -390,6 +391,14 @@ void VEvndispRunParameter::print( int iEv )
 	cout << endl;
 	cout << "File: " << fsourcefile << " (sourcetype " << fsourcetype;
 	cout << ")" << endl;
+	if( useDBTextFiles() )
+	{
+		cout << "Using database files for slow control data from " << fDBTextDirectory << endl;
+	}
+	else if( useDB() )
+	{
+		cout << "Using database for slow control data" << endl;
+	}
 	cout << "===========" << endl;
 	cout << fEventDisplayDate;
 	if( fIsMC )

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -182,7 +182,7 @@ void VImageAnalyzer::doAnalysis()
 	}
 	
 	///////////////////////////////////////////////////////////////////////////////////////////
-	// set parameters for image parameter calculation
+	// set parameters required for image parameter calculation
 	fVImageParameterCalculation->setDetectorGeometry( getDetectorGeometry() );
 	fVImageParameterCalculation->setParameters( getImageParameters() );
 	
@@ -328,12 +328,14 @@ void VImageAnalyzer::fillOutputTree()
 		getAnaHistos()->fillL2DiagnosticTree( getRunNumber(), getTelescopeEventNumber( getTelID() ),
 											  0, 0, getFADCstopTZero(), getFADCstopSums() );
 	}
+	// fill (optionally) image/border tree lists
+	fVImageParameterCalculation->fillImageBorderPixelTree();
 	
 	// fill some basic run parameters
 	getImageParameters()->fimagethresh = getImageThresh();
 	getImageParameters()->fborderthresh = getBorderThresh();
-	getImageParameters()->fncluster_cleaned = getNcluster_cleaned(); // HP
-	getImageParameters()->fncluster_uncleaned = getNcluster_uncleaned(); // HP
+	getImageParameters()->fncluster_cleaned = getNcluster_cleaned();
+	getImageParameters()->fncluster_uncleaned = getNcluster_uncleaned();
 	getImageParameters()->fsumfirst = getSumFirst();
 	getImageParameters()->fsumwindow = getSumWindow();
 	getImageParameters()->fsumwindow_2 = getSumWindow_2();
@@ -501,7 +503,7 @@ void VImageAnalyzer::initOutput()
 			cout << "ERROR: unable to create eventdisplay output file: " << fRunPar->foutputfileName.c_str() << endl;
 			cout << "exiting..." << endl;
 			cout << endl;
-			exit( 0 );
+			exit( EXIT_FAILURE );
 		}
 	}
 	
@@ -554,19 +556,21 @@ void VImageAnalyzer::initTrees()
 	// now book the trees (for MC with additional MC block)
 	// tree versioning numbers used in mscw_energy
 	char i_text[300];
-	char i_textTitle[300];
 	sprintf( i_text, "tpars" );
-	sprintf( i_textTitle, "Event Parameters (Telescope %d, VERSION %d)", getTelID() + 1, fRunPar->getEVNDISP_TREE_VERSION() );
+	ostringstream iSTRText;
+	iSTRText << "Event Parameters (Telescope " << getTelID() + 1;
+	iSTRText << ", VERSION " << fRunPar->getEVNDISP_TREE_VERSION() << ")";
 	if( getRunParameter()->fShortTree )
 	{
-		sprintf( i_textTitle, "%s (short tree)", i_textTitle );
+		iSTRText << " (short tree)";
 	}
-	fVImageParameterCalculation->getParameters()->initTree( i_text, i_textTitle, fReader->isMC(), false, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
+	fVImageParameterCalculation->getParameters()->initTree( i_text, iSTRText.str().c_str(), fReader->isMC(), false, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
 	
 	// for log likelihood method, book a second image parameter tree
 	if( fRunPar->fImageLL )
 	{
 		sprintf( i_text, "lpars" );
+		char i_textTitle[300];
 		sprintf( i_textTitle, "Event Parameters, loglikelihood (Telescope %d)", getTelID() + 1 );
 		fVImageParameterCalculation->getLLParameters()->initTree( i_text, i_textTitle, fReader->isMC(), true, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
 	}

--- a/src/VImageParameter.cpp
+++ b/src/VImageParameter.cpp
@@ -7,11 +7,14 @@
 
 #include "VImageParameter.h"
 
-VImageParameter::VImageParameter( unsigned int iShortTree )
+VImageParameter::VImageParameter(
+	unsigned int iShortTree,
+	bool iWriteNImagePixels )
 {
 	fMC = false;
 	tpars = 0;
 	fShortTree = iShortTree;
+	fWriteNImagePixels = iWriteNImagePixels;
 	
 	reset();
 }
@@ -57,11 +60,6 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 		tpars->Branch( "fncluster_cleaned", &fncluster_cleaned, "fncluster_cleaned/I" );
 		tpars->Branch( "fncluster_uncleaned", &fncluster_uncleaned, "fncluster_uncleaned/I" );
 	}
-	
-	// telescope position in shower coordinates
-	//tpars->Branch( "Tel_x_SC", &Tel_x_SC, "Tel_x_SC/D" );
-	//tpars->Branch( "Tel_y_SC", &Tel_y_SC, "Tel_y_SC/D" );
-	//tpars->Branch( "Tel_z_SC", &Tel_z_SC, "Tel_z_SC/D" );
 	
 	// MC parameters
 	if( iMC && fShortTree < 1 )
@@ -122,7 +120,7 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 	tpars->Branch( "sinphi", &sinphi, "sinphi/F" );
 	
 	tpars->Branch( "ntubes", &ntubes, "ntubes/s" );
-	// MS contains number of triggered pixels
+	// contains number of triggered pixels
 	tpars->Branch( "trig_tubes", &trig_tubes, "trig_tubes/s" );
 	tpars->Branch( "nzerosuppressed", &nzerosuppressed, "nzerosuppressed/s" );
 	tpars->Branch( "nsat", &nsat, "nsat/s" );
@@ -178,7 +176,6 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 	}
 	
 	// log likelihood fit errors/results
-	
 	tpars->Branch( "Fitstat", &Fitstat, "Fitstat/I" );
 	if( iLL )
 	{
@@ -205,6 +202,22 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 		tpars->Branch( "dsigmaY", &dsigmaY, "dsigmaY/F" );
 		tpars->Branch( "signal", &signal, "signal/F" );
 		tpars->Branch( "dsignal", &dsignal, "dsignal/F" );
+	}
+	tpars->Branch( "dcen_x", &dcen_x, "dcen_x/F" );
+	tpars->Branch( "dcen_y", &dcen_y, "dcen_y/F" );
+	tpars->Branch( "dlength", &dlength, "dlength/F" );
+	tpars->Branch( "dwidth", &dwidth, "dwidth/F" );
+	tpars->Branch( "dphi", &dphi, "dphi/F" );
+	
+	// image / border pixel list
+	if( fWriteNImagePixels )
+	{
+		// image pixels
+		tpars->Branch( "PixelListN", &PixelListN, "PixelListN/i" );
+		tpars->Branch( "PixelID", PixelID, "PixelID[PixelListN]/i" );
+		tpars->Branch( "PixelType", PixelType, "PixelType[PixelListN]/i" );
+		tpars->Branch( "PixelIntensity", PixelIntensity, "PixelIntensity[PixelListN]/F" );
+		tpars->Branch( "PixelTimingT0", PixelTimingT0, "PixelTimingT0[PixelListN]/F" );
 	}
 }
 
@@ -358,6 +371,14 @@ void VImageParameter::reset( unsigned int resetLevel )
 	houghContained = 0.;
 	houghMuonValid = 0;
 	
+	if( fWriteNImagePixels )
+	{
+		PixelListN = 0;
+		memset( PixelID, 0, VDST_MAXCHANNELS * sizeof( unsigned int ) );
+		memset( PixelType, 0, VDST_MAXCHANNELS * sizeof( unsigned int ) );
+		memset( PixelIntensity, 0, VDST_MAXCHANNELS * sizeof( float ) );
+		memset( PixelTimingT0, 0, VDST_MAXCHANNELS * sizeof( float ) );
+	}
 }
 
 

--- a/src/VImageParameterCalculation.cpp
+++ b/src/VImageParameterCalculation.cpp
@@ -16,8 +16,8 @@ VImageParameterCalculation::VImageParameterCalculation( unsigned int iShortTree,
 		cout << "VImageParameterCalculation::VImageParameterCalculation()" << endl;
 	}
 	fData = iData;
-	fParGeo = new VImageParameter( iShortTree );
-	fParLL =  new VImageParameter( iShortTree );
+	fParGeo = new VImageParameter( iShortTree, fData->getRunParameter()->fWriteImagePixelList );
+	fParLL =  new VImageParameter( iShortTree, fData->getRunParameter()->fWriteImagePixelList );
 	fboolCalcGeo = false;
 	fboolCalcTiming = false;
 	fDetectorGeometry = 0;
@@ -288,7 +288,7 @@ void VImageParameterCalculation::muonRingFinder()
 	if( !getDetectorGeo() )
 	{
 		cout << "VImageParameterCalculation::muonRingFinder error: detector geometry not defined" << endl;
-		exit( 0 );
+		exit( EXIT_FAILURE );
 	}
 	
 	int counter = 0, safty = 0, noChangeX = 0, noChangeY = 0;
@@ -411,7 +411,7 @@ void VImageParameterCalculation::muonRingFinder()
 		x0[0] = x0[1];
 		
 		///*********************************************
-		// TAKE A STEP IN THE Y-DRIRECTION ?
+		// TAKE A STEP IN THE Y-DIRECTION ?
 		///*********************************************
 		//try a different x0[1], see if sigma of r decreases
 		x0[1] = x0[0];
@@ -529,7 +529,7 @@ void VImageParameterCalculation::sizeInMuonRing()
 	}
 	
 	unsigned int i;
-	double xi, yi, rp, size = 0.0, x0, y0, radius, si;
+	double xi, yi, size = 0.0, x0, y0, radius, si;
 	int totalPixels = 0;
 	int offPixels = 0;
 	double xc = 0.; //Centroid x coordinate
@@ -542,7 +542,7 @@ void VImageParameterCalculation::sizeInMuonRing()
 	{
 		xi = getDetectorGeo()->getX()[i];
 		yi = getDetectorGeo()->getY()[i];
-		rp = sqrt( pow( xi - x0 , 2 ) + pow( yi - y0, 2 ) );
+		double rp = sqrt( pow( xi - x0 , 2 ) + pow( yi - y0, 2 ) );
 		
 		if( rp > radius - 0.15 && rp < radius + 0.15 )
 		{
@@ -762,27 +762,6 @@ void VImageParameterCalculation::houghInitialization()
 }
 
 
-//Placeholder for Hough transform based parametrization algorithm
-void VImageParameterCalculation::houghMuonRingFinder()
-{
-
-
-}
-
-
-//Placeholder for Hough transform based size calculator
-void VImageParameterCalculation::houghSizeInMuonRing()
-{
-
-
-
-
-
-
-
-
-
-}
 
 
 //Hough transform muon identification algorithm.
@@ -860,15 +839,14 @@ void VImageParameterCalculation::houghMuonPixelDistribution()
 
 void VImageParameterCalculation::calcTriggerParameters( vector<bool> fTrigger )
 {
-	// MS: This function does:
 	// Calculate the trigger-level centroids
-	double sumx_trig = 0.;                        // MS
-	double sumy_trig = 0.;                        // MS
-	double sumx2_trig = 0.;                       // MS
-	double sumy2_trig = 0.;                       // MS
+	double sumx_trig = 0.;
+	double sumy_trig = 0.;
+	double sumx2_trig = 0.;
+	double sumy2_trig = 0.;
 	int trig_tubes = 0;
 	
-	// MS: calculated trigger-level parameters
+	// calculate trigger-level parameters
 	// loop over all pixels
 	for( unsigned int j = 0; j < fTrigger.size(); j++ )
 	{
@@ -880,30 +858,25 @@ void VImageParameterCalculation::calcTriggerParameters( vector<bool> fTrigger )
 			double xi = getDetectorGeo()->getX()[j];
 			double yi = getDetectorGeo()->getY()[j];
 			
-			sumx_trig += xi;                      // MS
-			sumy_trig += yi;                      // MS
-			sumx2_trig += xi * xi;                // MS
-			sumy2_trig += yi * yi;                // MS
+			sumx_trig += xi;
+			sumy_trig += yi;
+			sumx2_trig += xi * xi;
+			sumy2_trig += yi * yi;
 		}
 	}
 	fParGeo->trig_tubes = trig_tubes;
 	
-	//  MS: store the trigger-level information
 	if( fParGeo->trig_tubes != 0 )
 	{
-		// MS
 		const double xmean_trig = sumx_trig / trig_tubes;
-		// MS
 		const double ymean_trig = sumy_trig / trig_tubes;
-		// MS
 		const double x2mean_trig = sumx2_trig / trig_tubes;
-		// MS
 		const double y2mean_trig = sumy2_trig / trig_tubes;
 		
-		fParGeo->cen_x_trig = xmean_trig;         // MS
-		fParGeo->cen_y_trig = ymean_trig;         // MS
-		fParGeo->cen_x2_trig = x2mean_trig;       // MS
-		fParGeo->cen_y2_trig = y2mean_trig;       // MS
+		fParGeo->cen_x_trig = xmean_trig;
+		fParGeo->cen_y_trig = ymean_trig;
+		fParGeo->cen_x2_trig = x2mean_trig;
+		fParGeo->cen_y2_trig = y2mean_trig;
 	}
 	
 }
@@ -941,7 +914,7 @@ void VImageParameterCalculation::calcParameters()
 	if( !getDetectorGeo() )
 	{
 		cout << "VImageParameterCalculation::calcParameters error: detector geometry not defined" << endl;
-		exit( 0 );
+		exit( EXIT_FAILURE );
 	}
 	
 	double sumsig = 0;
@@ -962,12 +935,12 @@ void VImageParameterCalculation::calcParameters()
 	double sumLowGain = 0.;
 	
 	// calculate mean ped and pedvar
-	double nPixPed = 0.;
 	fParGeo->fmeanPed_Image = 0.;
 	fParGeo->fmeanPedvar_Image = 0.;
 	
 	if( fData->getRunParameter()->doFADCAnalysis() && fData->getReader()->hasFADCTrace() )
 	{
+		double nPixPed = 0.;
 		for( unsigned int j = 0; j < fData->getImageBorderNeighbour().size(); j++ )
 		{
 			if( fData->getImageBorderNeighbour()[j] )
@@ -1017,19 +990,18 @@ void VImageParameterCalculation::calcParameters()
 			pntubesBrightNoImage++;
 		}
 		
+		// loop over image tubes
 		// select image or border pixel
 		if( fData->getImage()[j] || fData->getBorder()[j] )
 		{
 			pntubes += 1;
 			
-			// loop over image tubes
-			
 			double xi = getDetectorGeo()->getX()[j];
 			double yi = getDetectorGeo()->getY()[j];
 			
-			const double si = ( double )fData->getSums()[j]; // charge (dc)
+			double si = ( double )fData->getSums()[j]; // charge (dc)
 			sumsig += si;
-			const double si2 = ( double )fData->getSums2()[j];
+			double si2 = ( double )fData->getSums2()[j];
 			sumsig_2 += si2;
 			// sum in outer ring
 			if( getDetectorGeo()->getNNeighbours()[j] < getDetectorGeo()->getMaxNeighbour() )
@@ -1153,29 +1125,16 @@ void VImageParameterCalculation::calcParameters()
 	else
 	{
 		double xmean = 0.;
-		if( sumsig > 0. )
-		{
-			xmean = sumxsig / sumsig;
-		}
 		double ymean = 0.;
-		if( sumsig > 0. )
-		{
-			ymean = sumysig / sumsig;
-		}
-		
 		double x2mean = 0.;
-		if( sumsig > 0. )
-		{
-			x2mean = sumx2sig / sumsig;
-		}
 		double y2mean = 0.;
-		if( sumsig > 0. )
-		{
-			y2mean = sumy2sig / sumsig;
-		}
 		double xymean = 0.;
 		if( sumsig > 0. )
 		{
+			xmean = sumxsig / sumsig;
+			ymean = sumysig / sumsig;
+			x2mean = sumx2sig / sumsig;
+			y2mean = sumy2sig / sumsig;
 			xymean = sumxysig / sumsig;
 		}
 		
@@ -1260,18 +1219,12 @@ void VImageParameterCalculation::calcParameters()
 		double length2 = ( sdevx2 + sdevy2 + z ) / 2.0;
 		if( length2 < ZeroTolerence )
 		{
-			//if ( length2 < -(ZeroTolerence) )
-			//	throw Error("Length squared is less than -ZeroTolerence");
-			
 			length2 = 0;
 		}
 		
 		double width2  = ( sdevx2 + sdevy2 - z ) / 2.0;
 		if( width2 < ZeroTolerence )
 		{
-			//if ( width2 < -(ZeroTolerence) )
-			//throw Error("Width squared is less than -ZeroTolerence");
-			
 			width2 = 0;
 		}
 		
@@ -1324,7 +1277,6 @@ void VImageParameterCalculation::calcParameters()
 		////////////////////////////////////////////////////////////////////////////
 		
 		const double sinalpha = ( dist > ZeroTolerence ) ? miss / dist : 0;
-		//  if(sinalpha>1.0)sinalpha=1.0; // Floating point sanity check
 		
 		const double alpha = fabs( TMath::RadToDeg() * asin( sinalpha ) );
 		
@@ -1354,8 +1306,6 @@ void VImageParameterCalculation::calcParameters()
 		////////////////////////////////////////////////////////////////////////////
 		
 		double asymmetry = 0;
-		double minorasymmetry = 0;
-		
 		if( length2 > ZeroTolerence )
 		{
 			const double x3mean = sumx3sig / sumsig;
@@ -1383,23 +1333,6 @@ void VImageParameterCalculation::calcParameters()
 				if( asymmetry3length3 < 0 )
 				{
 					asymmetry = -asymmetry;
-				}
-			}
-			
-			if( width2 > ZeroTolerence )
-			{
-				const double minorasymmetry3width3 =
-					-sdevx3 * sinphi * sinphi2 + 3.0 * sdevx2y * cosphi * sinphi2 -
-					3.0 * sdevxy2 * sinphi * cosphi2 + sdevy3 * cosphi * cosphi2;
-					
-				if( fabs( minorasymmetry3width3 ) > ZeroTolerence )
-				{
-					minorasymmetry = pow( fabs( minorasymmetry3width3 ),
-										  0.333333333333 ) / width;
-					if( minorasymmetry3width3 < 0 )
-					{
-						minorasymmetry = -minorasymmetry;
-					}
 				}
 			}
 		}
@@ -2206,5 +2139,58 @@ void VImageParameterCalculation::setImageBorderPixelPosition( VImageParameter* i
 			}
 		}
 		iPar->setImageBorderPixelPosition( i_x, i_y );
+	}
+}
+
+
+/*
+    fill image/border pixel to image parameter tree
+    (optional)
+
+    PixelType == 0: Pe > 0 and not image and not border pixel
+    PixelType == 1: image pixel
+    PixelType == 2: border pixel
+    PixelType == 3: neighbour pixel to image/border
+
+*/
+void VImageParameterCalculation::fillImageBorderPixelTree()
+{
+	if( !fParGeo )
+	{
+		return;
+	}
+	if( !fParGeo->isWriteNImagePixels() )
+	{
+		return;
+	}
+	fParGeo->PixelListN = 0;
+	for( unsigned int i = 0; i < fData->getSums().size(); i++ )
+	{
+		// decide of pixel should be added to list written to tree
+		fParGeo->PixelID[fParGeo->PixelListN] = i;
+		fParGeo->PixelType[fParGeo->PixelListN] = 99;
+		if( fData->getImage()[i] )
+		{
+			fParGeo->PixelType[fParGeo->PixelListN] = 1;
+		}
+		else if( fData->getBorder()[i] )
+		{
+			fParGeo->PixelType[fParGeo->PixelListN] = 2;
+		}
+		else if( fData->getImageBorderNeighbour()[i] )
+		{
+			fParGeo->PixelType[fParGeo->PixelListN] = 3;
+		}
+		if( fParGeo->PixelType[fParGeo->PixelListN] < 99 )
+		{
+			fParGeo->PixelIntensity[fParGeo->PixelListN] = fData->getSums()[i];
+			fParGeo->PixelTimingT0[fParGeo->PixelListN] = fData->getPulseTime()[i];
+			// low-gain channel: add '10' to pixel type
+			if( fData->getHiLo()[i] )
+			{
+				fParGeo->PixelType[fParGeo->PixelListN] += 10;
+			}
+			fParGeo->PixelListN++;
+		}
 	}
 }

--- a/src/VPointing.cpp
+++ b/src/VPointing.cpp
@@ -17,7 +17,6 @@ VPointing::VPointing( unsigned int iTelID )
 	fTelAzimuthDB = 0.;
 	fTelElevationDB = 0.;
 	fNEventsWithNoDBPointing = 0;
-	fPointingDB = 0;
 	fEventStatus = 0;
 	
 	fPointingErrorX = 0.;
@@ -78,7 +77,10 @@ void VPointing::setTelPointing( int MJD, double time, bool iUseDB, bool iFillPoi
 	
 }
 
-void VPointing::getPointingFromDB( int irun, string iTCorrection, string iVPMDirectory, bool iVPMDB, bool iUncalibratedVPM )
+void VPointing::getPointingFromDB(
+	int irun, string iTCorrection,
+	bool iVPMDB, bool iUncalibratedVPM,
+	string iDBTextDirectory )
 {
 	fPointingType = 2;
 	if( iVPMDB == true )
@@ -88,10 +90,6 @@ void VPointing::getPointingFromDB( int irun, string iTCorrection, string iVPMDir
 	else if( iUncalibratedVPM == true )
 	{
 		fPointingType = 5;    // read uncalibrated VPM data from VERITAS DB
-	}
-	else if( iVPMDirectory.size() > 0 )
-	{
-		fPointingType = 4;    // read VPM data from a text file
 	}
 	else if( iTCorrection.size() > 0 )
 	{
@@ -105,7 +103,7 @@ void VPointing::getPointingFromDB( int irun, string iTCorrection, string iVPMDir
 #ifdef RUNWITHDB
 	fPointingDB = new VPointingDB( fTelID, irun );
 	fPointingDB->setObservatory( fObsLongitude * TMath::RadToDeg(), fObsLatitude * TMath::RadToDeg() );      // work in [deg]
-	fPointingDB->initialize( iTCorrection, iVPMDirectory, iVPMDB, iUncalibratedVPM );
+	fPointingDB->initialize( iTCorrection, iVPMDB, iUncalibratedVPM, iDBTextDirectory );
 	if( !fPointingDB->isGood() )
 	{
 		cout << endl;

--- a/src/VPointingCorrectionsTreeReader.cpp
+++ b/src/VPointingCorrectionsTreeReader.cpp
@@ -80,6 +80,6 @@ float VPointingCorrectionsTreeReader::getCorrected_phi( float cen_x, float cen_y
 	
 	const double ac = ( d + s ) * ymean + 2.0 * sdevxy * xmean;
 	const double bc = 2.0 * sdevxy * ymean - ( d - s ) * xmean;
-
+	
 	return atan2( ac, bc );
 }

--- a/src/VPointingCorrectionsTreeReader.cpp
+++ b/src/VPointingCorrectionsTreeReader.cpp
@@ -80,7 +80,6 @@ float VPointingCorrectionsTreeReader::getCorrected_phi( float cen_x, float cen_y
 	
 	const double ac = ( d + s ) * ymean + 2.0 * sdevxy * xmean;
 	const double bc = 2.0 * sdevxy * ymean - ( d - s ) * xmean;
-	const double cc = sqrt( ac * ac + bc * bc );
-	
-	return atan2( ac / cc, bc / cc );
+
+	return atan2( ac, bc );
 }

--- a/src/VPointingDB.cpp
+++ b/src/VPointingDB.cpp
@@ -44,10 +44,12 @@ VPointingDB::VPointingDB( unsigned int iTelID, unsigned int irun )
 	fTrackingCorrections = 0;
 }
 
-bool VPointingDB::initialize( string iTPointCorrection, string iVPMDirectory, bool iVPMDB, bool iUncalibratedVPM )
+/*
+ * setup tracking corrections (expert use!)
+ *
+*/
+void VPointingDB::readTrackingCorrections( string iTPointCorrection )
 {
-
-	// setup tracking corrections (expert use!)
 	if( iTPointCorrection.size() > 0 )
 	{
 		fTrackingCorrections = new VTrackingCorrections( fTelID );
@@ -55,20 +57,20 @@ bool VPointingDB::initialize( string iTPointCorrection, string iVPMDirectory, bo
 		{
 			cout << "VPointingDB: error while reading tracking correction from VERITAS database" << endl;
 			cout << "             date wrong? (example for SQL date format: \"2007-10-05\")" << endl;
-			exit( -1 );
+			exit( EXIT_FAILURE );
 		}
 	}
 	else
 	{
 		fTrackingCorrections = 0;
 	}
-	
+}
+
+void VPointingDB::setup_DB_connection()
+{
 	string iTempS  = getDBServer();
 	iTempS        += "/VERITAS";
-	
-	//std::cout<<"VPointingDB::initialize "<<std::endl;
 	fmy_connection = new VDB_Connection( iTempS.c_str(), "readonly", "" ) ;
-	//std::cout<<"fmy_connection->Get_Connection_Status() "<<fmy_connection->Get_Connection_Status() <<std::endl;
 	
 	if( !fmy_connection->Get_Connection_Status() )
 	{
@@ -76,22 +78,50 @@ bool VPointingDB::initialize( string iTPointCorrection, string iVPMDirectory, bo
 		fStatus = false;
 		exit( EXIT_FAILURE );
 	}
+}
+
+
+bool VPointingDB::initialize(
+	string iTPointCorrection,
+	bool iVPMDB, bool iUncalibratedVPM, string iDBTextDirectory )
+{
+
+	readTrackingCorrections( iTPointCorrection );
 	
-	fStatus = getDBRunInfo();
-	// read pointing from VPM text file
-	if( iVPMDirectory.size() > 0 )
+	if( iDBTextDirectory.size() > 0 )
 	{
-		fStatus = readPointingFromVPMTextFile( iVPMDirectory );
+		fmy_connection = 0;
+		fStatus = getDBTextRunInfo( iDBTextDirectory );
+	}
+	else
+	{
+		setup_DB_connection();
+		fStatus = getDBRunInfo();
 	}
 	// read pointing from calibrated pointing monitor (VPM) entries in DB
-	else if( iVPMDB )
+	if( iVPMDB )
 	{
-		fGoodVPM = readPointingCalibratedVPMFromDB();
+		if( iDBTextDirectory.size() > 0 )
+		{
+			fGoodVPM = readPointingCalibratedVPMFromDBTextFile( iDBTextDirectory );
+		}
+		else
+		{
+			fGoodVPM = readPointingCalibratedVPMFromDB();
+		}
 		// fall back to DB pointing if reading pointing monitor data failed
 		if( !fGoodVPM )
 		{
-			cout << "VPointingDB warning: quality-selected VPM data not available, reverting to encoder data for telescope " << getTelID() + 1 << " for full duration of run " << fRunNumber << endl;
-			fStatus = readPointingFromDB();
+			cout << "VPointingDB warning: quality-selected VPM data not available, reverting to encoder data for telescope ";
+			cout << getTelID() + 1 << " for full duration of run " << fRunNumber << endl;
+			if( iDBTextDirectory.size() > 0 )
+			{
+				fStatus = readPointingFromDBText( iDBTextDirectory );
+			}
+			else
+			{
+				fStatus = readPointingFromDB();
+			}
 		}
 		else
 		{
@@ -340,10 +370,35 @@ void VPointingDB::getDBMJDTime( string itemp, int& MJD, double& Time, bool bStri
 	}
 }
 
+bool VPointingDB::getDBTextRunInfo( string iDBTextDirectory )
+{
+	VSQLTextFileReader a( iDBTextDirectory, fRunNumber, "runinfo" );
+	if( !a.isGood() )
+	{
+		return false;
+	}
+	getDBMJDTime( a.getValue_from_key( "data_start_time" ), fMJDRunStart, fTimeRunStart, true );
+	getDBMJDTime( a.getValue_from_key( "data_end_time" ), fMJDRunStart, fTimeRunStopp, true );
+	// add 1 min to be save
+	fTimeRunStopp += 60.;
+	fDBSourceName = a.getValue_from_key( "source_id" );
+	float dist = atof( a.getValue_from_key( "offset_distance" ).c_str() );
+	float angl = atof( a.getValue_from_key( "offset_angle" ).c_str() );
+	fDBWobbleNorth = dist * cos( angl * TMath::DegToRad() );
+	fDBWobbleEast = dist * sin( angl * TMath::DegToRad() );
+	VSQLTextFileReader t( iDBTextDirectory, fRunNumber, "target" );
+	if( !t.isGood() )
+	{
+		return false;
+	}
+	fDBTargetDec = atof( t.getValue_from_key( "decl" ).c_str() ) * TMath::RadToDeg();
+	fDBTargetRA = atof( t.getValue_from_key( "ra" ).c_str() ) * TMath::RadToDeg();
+	return true;
+}
+
 
 bool VPointingDB::getDBRunInfo()
 {
-
 	if( !fmy_connection->Get_Connection_Status() )
 	{
 		return false;
@@ -398,88 +453,58 @@ bool VPointingDB::getDBRunInfo()
 }
 
 
-bool VPointingDB::readPointingFromVPMTextFile( string iDirectory )
+/*
+    read calibrated (default) pointing monitor data from DBTextfile
+*/
+bool VPointingDB::readPointingCalibratedVPMFromDBTextFile( string iDBTextDirectory )
 {
-	if( iDirectory.size() < 1 )
+	// VPM quality flag
+	VSQLTextFileReader a( iDBTextDirectory, fRunNumber, "rundqm" );
+	if( !a.isGood() )
+	{
+		cout << "Error reading VPM status flags" << endl;
+		return false;
+	}
+	int maskVPM = atoi( a.getValue_from_key( "vpm_config_mask" ).c_str() );
+	if( !check_maskVPM( maskVPM ) )
 	{
 		return false;
 	}
 	
-	char fname[1200];
-	sprintf( fname, "%s/pointing_VPM.%d.t%d.dat", iDirectory.c_str(), fRunNumber, getTelID() + 1 );
-	
-	ifstream is;
-	is.open( fname );
-	if( !is )
+	// VPM data
+	VSQLTextFileReader vpm( iDBTextDirectory, fRunNumber, "VPM", getTelID() );
+	if( !vpm.isGood() || !vpm.checkDataVectorsForSameLength() )
 	{
-		cout << "VPointingDB: error opening pointing monitor data file: " << fname << endl;
-		cout << "exiting...." << endl;
-		exit( 0 );
+		cout << "Error reading VPM data from DBText for telescope " << getTelID() + 1 << endl;
+		return false;
 	}
-	string is_line;
-	int nLines = 0;
+	string itemp;
 	double iMJD = 0.;
-	double iTemp = 0.;
-	double iRA = 0.;
-	double iDec = 0.;
 	double iITime = 0.;
 	double az = 0.;
 	double ze = 0.;
-	
-	while( getline( is, is_line ) )
+	vector< double > iMJD_v = vpm.getValueVector_from_key_as_double( "mjd" );
+	vector< double > iRA = vpm.getValueVector_from_key_as_double( "ra" );
+	vector< double > iDec = vpm.getValueVector_from_key_as_double( "decl" );
+	for( unsigned int i = 0; i < iMJD_v.size(); i++ )
 	{
-		// This is the expected format (vpm v.0.9):
-		// MJD REQ_AZ REQ_EL REQ_RA2000 REQ_DEC2000 POSITIONER_RA2000 POSITIONER_DEC2000 VPM_AZ VPM_EL VPM_RA2000 VPM_DEC2000
-		// test line for completeness (expect 11 columns)
-		int nC = 0;
-		istringstream is_streamT( is_line );
-		while( !( is_streamT >> std::ws ).eof() )
-		{
-			is_streamT >> iTemp;
-			nC++;
-		};
-		if( nC != 11 )
-		{
-			cout << "\t warning: incomplete line in pointing monitor file" << endl;
-			continue;
-		}
-		// read a new line
-		istringstream is_stream( is_line );
-		is_stream >> iMJD;
+		iMJD = iMJD_v[i];
 		iITime = modf( iMJD, &iMJD );
-		// ignore the following 8 columns
-		for( int i = 0; i < 8; i++ )
-		{
-			is_stream >> iTemp;
-		}
-		is_stream >> iRA;
-		is_stream >> iDec;
-		if( iRA > 0. && iDec > 0. )
-		{
-			fDBMJD.push_back( ( unsigned int )( iMJD ) );
-			fDBTime.push_back( iITime * 86400. );
-			fDBTelElevationRaw.push_back( 0. );
-			fDBTelAzimuthRaw.push_back( 0. );
-			fDBTelRA.push_back( iRA * degrad );
-			fDBTelDec.push_back( iDec * degrad );
-			getHorizonCoordinates( fDBMJD.back(), fDBTime.back(), iDec * degrad, iRA * degrad, az, ze );
-			fDBTelElevation.push_back( 90. - ze );
-			fDBTelAzimuth.push_back( az );
-			fDBTelExpectedElevation.push_back( 0. );
-			fDBTelExpectedAzimuth.push_back( 0. );
-		}
-		nLines++;
-	};
-	cout << "Reading pointing data from VERITAS pointing monitor file for telescope " << getTelID() + 1;
-	cout << ": found " << nLines << " rows in file " << fname << endl;
-	if( nLines == 0 )
-	{
-		return false;
+		fDBMJD.push_back( ( unsigned int )( iMJD ) );
+		fDBTime.push_back( iITime * 86400. );
+		fDBTelElevationRaw.push_back( 0. );
+		fDBTelAzimuthRaw.push_back( 0. );
+		fDBTelRA.push_back( iRA[i] * degrad );
+		fDBTelDec.push_back( iDec[i] * degrad );
+		getHorizonCoordinates( fDBMJD.back(), fDBTime.back(), iDec[i] * degrad, iRA[i] * degrad, az, ze );
+		fDBTelElevation.push_back( 90. - ze );
+		fDBTelAzimuth.push_back( az );
+		fDBTelExpectedElevation.push_back( 0. );
+		fDBTelExpectedAzimuth.push_back( 0. );
 	}
-	
 	fDBNrows = fDBMJD.size();
 	
-	return true;
+	return ( fDBNrows != 0 );
 }
 
 /*
@@ -498,7 +523,6 @@ bool VPointingDB::readPointingCalibratedVPMFromDB()
 	string iTempS  = getDBServer();
 	iTempS += "/VOFFLINE";
 	
-	//std::cout<<"VPointingDB::readPointingCalibratedVPMFromDB "<<std::endl;
 	VDB_Connection my_connection( iTempS.c_str(), "readonly", "" ) ;
 	if( !my_connection.Get_Connection_Status() )
 	{
@@ -534,7 +558,57 @@ bool VPointingDB::readPointingCalibratedVPMFromDB()
 		return false;
 	}
 	int maskVPM = atoi( flag_row->GetField( 0 ) );
+	if( !check_maskVPM( maskVPM ) )
+	{
+		return false;
+	}
 	
+	// loop over all db entries
+	string itemp;
+	double iMJD;
+	double iITime = 0.;
+	double az = 0.;
+	double ze = 0.;
+	double iRA = 0.;
+	double iDec = 0.;
+	
+	for( int j = 0; j < fNRows; j++ )
+	{
+		TSQLRow* db_row = db_res->Next();
+		if( !db_row )
+		{
+			continue;
+		}
+		
+		iMJD = atof( db_row->GetField( 0 ) );
+		iITime = modf( iMJD, &iMJD );
+		fDBMJD.push_back( ( unsigned int )iMJD );
+		fDBTime.push_back( iITime * 86400. );
+		fDBTelElevationRaw.push_back( 0. );
+		fDBTelAzimuthRaw.push_back( 0. );
+		iRA = atof( db_row->GetField( 1 ) );
+		iDec = atof( db_row->GetField( 2 ) );
+		fDBTelRA.push_back( iRA * degrad );
+		fDBTelDec.push_back( iDec * degrad );
+		getHorizonCoordinates( fDBMJD.back(), fDBTime.back(), iDec * degrad, iRA * degrad, az, ze );
+		fDBTelElevation.push_back( 90. - ze );
+		fDBTelAzimuth.push_back( az );
+		fDBTelExpectedElevation.push_back( 0. );
+		fDBTelExpectedAzimuth.push_back( 0. );
+	}
+	
+	fDBNrows = fDBMJD.size();
+	
+	return true;
+}
+
+/*
+ * check quality flag of VPM that current
+ * telescope has correct VPM data
+ *
+ */
+bool VPointingDB::check_maskVPM( int maskVPM )
+{
 	if( getTelID() == 0 )      // T1 bad
 	{
 		if( maskVPM == 0 || maskVPM == 2 || maskVPM == 4 || maskVPM == 8 )
@@ -579,43 +653,6 @@ bool VPointingDB::readPointingCalibratedVPMFromDB()
 			return false;
 		}
 	}
-	
-	// loop over all db entries
-	string itemp;
-	double iMJD;
-	double iITime = 0.;
-	double az = 0.;
-	double ze = 0.;
-	double iRA = 0.;
-	double iDec = 0.;
-	
-	for( int j = 0; j < fNRows; j++ )
-	{
-		TSQLRow* db_row = db_res->Next();
-		if( !db_row )
-		{
-			continue;
-		}
-		
-		iMJD = atof( db_row->GetField( 0 ) );
-		iITime = modf( iMJD, &iMJD );
-		fDBMJD.push_back( ( unsigned int )iMJD );
-		fDBTime.push_back( iITime * 86400. );
-		fDBTelElevationRaw.push_back( 0. );
-		fDBTelAzimuthRaw.push_back( 0. );
-		iRA = atof( db_row->GetField( 1 ) );
-		iDec = atof( db_row->GetField( 2 ) );
-		fDBTelRA.push_back( iRA * degrad );
-		fDBTelDec.push_back( iDec * degrad );
-		getHorizonCoordinates( fDBMJD.back(), fDBTime.back(), iDec * degrad, iRA * degrad, az, ze );
-		fDBTelElevation.push_back( 90. - ze );
-		fDBTelAzimuth.push_back( az );
-		fDBTelExpectedElevation.push_back( 0. );
-		fDBTelExpectedAzimuth.push_back( 0. );
-	}
-	
-	fDBNrows = fDBMJD.size();
-	
 	return true;
 }
 
@@ -767,10 +804,46 @@ bool VPointingDB::readPointingUncalibratedVPMFromDB()
 	return true;
 }
 
+bool VPointingDB::readPointingFromDBText( string iDBTextDirectory )
+{
+	VSQLTextFileReader a( iDBTextDirectory, fRunNumber, "rawpointing", getTelID() );
+	if( !a.isGood() || !a.checkDataVectorsForSameLength() )
+	{
+		cout << "Error reading Raw pointing data from DBText for telescope " << getTelID() + 1 << endl;
+		return false;
+	}
+	vector< string > i_timestamp = a.getValueVector_from_key( "timestamp" );
+	vector< double > i_el_raw = a.getValueVector_from_key_as_double( "elevation_raw" );
+	vector< double > i_az_raw = a.getValueVector_from_key_as_double( "azimuth_raw" );
+	vector< double > i_el_meas = a.getValueVector_from_key_as_double( "elevation_meas" );
+	vector< double > i_az_meas = a.getValueVector_from_key_as_double( "azimuth_meas" );
+	vector< double > i_el_target = a.getValueVector_from_key_as_double( "elevation_target" );
+	vector< double > i_az_target = a.getValueVector_from_key_as_double( "azimuth_target" );
+	
+	int iMJD = 0;
+	double iTime = 0.;
+	for( unsigned int i = 0; i < i_timestamp.size(); i++ )
+	{
+		getDBMJDTime( i_timestamp[i], iMJD, iTime, false );
+		fDBMJD.push_back( ( unsigned int )iMJD );
+		fDBTime.push_back( iTime );
+		fDBTelElevationRaw.push_back( i_el_raw[i] * TMath::RadToDeg() );
+		fDBTelAzimuthRaw.push_back( i_az_raw[i] * TMath::RadToDeg() );
+		fDBTelElevation.push_back( i_el_meas[i] * TMath::RadToDeg() );
+		fDBTelAzimuth.push_back( i_az_meas[i] * TMath::RadToDeg() );
+		fDBTelRA.push_back( 0. );
+		fDBTelDec.push_back( 0. );
+		fDBTelExpectedElevation.push_back( i_el_target[i] * TMath::RadToDeg() );
+		fDBTelExpectedAzimuth.push_back( i_az_target[i] * TMath::RadToDeg() );
+	}
+	fDBNrows = fDBMJD.size();
+	return ( fDBNrows != 0 );
+}
+
 bool VPointingDB::readPointingFromDB()
 {
 
-	if( !fmy_connection->Get_Connection_Status() )
+	if( !fmy_connection || !fmy_connection->Get_Connection_Status() )
 	{
 		return false;
 	}
@@ -803,7 +876,6 @@ bool VPointingDB::readPointingFromDB()
 		return false;
 	}
 	TSQLResult* db_res = fmy_connection->Get_QueryResult();
-	
 	
 	int fNRows = db_res->GetRowCount();
 	
@@ -850,8 +922,7 @@ bool VPointingDB::readPointingFromDB()
 		fDBTelExpectedAzimuth.push_back( atof( db_row->GetField( 6 ) ) * 180. / TMath::Pi() );
 	}
 	fDBNrows = fDBMJD.size();
-	
-	return true;
+	return ( fDBNrows != 0 );
 }
 
 
@@ -871,8 +942,6 @@ void VPointingDB::getDBSourceCoordinates( string iSource, float& iEVNTargetDec, 
 		return;
 	}
 	TSQLResult* db_res = fmy_connection->Get_QueryResult();
-	
-	
 	
 	TSQLRow* db_row = db_res->Next();
 	

--- a/src/VReadRunParameter.cpp
+++ b/src/VReadRunParameter.cpp
@@ -944,6 +944,10 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 		{
 			fRunPara->fWriteExtraCalibTree = true;
 		}
+		else if( iTemp.rfind( "writeimagepixellist" ) < iTemp.size() )
+		{
+			fRunPara->fWriteImagePixelList = true;
+		}
 		else if( i > 1 )
 		{
 			cout << "unknown command line parameter: " << iTemp << endl;

--- a/src/VReadRunParameter.cpp
+++ b/src/VReadRunParameter.cpp
@@ -390,6 +390,7 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 		{
 			fRunPara->fPlotRaw = true;
 			fRunPara->fuseDB = false;
+			fRunPara->fDBTextDirectory = "";
 			fRunPara->fDBTracking = false;
 			fRunPara->fTargetName = "laser";
 			fRunPara->fdisplaymode = 1;
@@ -410,11 +411,23 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 		{
 			fRunPara->fFillMCHistos = true;
 		}
-		// use db for run infos
 		else if( iTemp.find( "usedbinfo" ) < iTemp.size() && !( iTemp.find( "donotusedbinfo" ) < iTemp.size() ) )
 		{
 			fRunPara->fuseDB = true;
 			isCompiledWithDB();
+		}
+		else if( iTemp.find( "dbtextdirectory" ) < iTemp.size() )
+		{
+			if( iTemp2.size() > 0 )
+			{
+				fRunPara->fDBTextDirectory = iTemp2;
+				i++;
+			}
+			else
+			{
+				cout << "error setting DB text directory" << endl;
+				return false;
+			}
 		}
 		else if( iTemp.find( "donotusedbinfo" ) < iTemp.size() )
 		{
@@ -613,21 +626,6 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 			{
 				fRunPara->fDBTrackingCorrections = "";
 				cout << "no date for T-Point correction given" << endl;
-				return false;
-			}
-		}
-		else if( iTemp.rfind( "-pointingmonitortxt" ) < iTemp.size() )
-		{
-			if( iTemp2.size() > 0 )
-			{
-				fRunPara->fPMTextFileDirectory = iTemp2;
-				fRunPara->fDBTracking = true;
-				i++;
-			}
-			else
-			{
-				fRunPara->fPMTextFileDirectory = "";
-				cout << "no pointing monitor text file directory give" << endl;
 				return false;
 			}
 		}
@@ -1022,6 +1020,7 @@ void VReadRunParameter::test_and_adjustParams()
 	{
 		fRunPara->fDBTracking = false;
 		fRunPara->fuseDB = false;
+		fRunPara->fDBTextDirectory = "";
 		fRunPara->fL2TimeCorrect = false;
 		fRunPara->fDBCameraRotationMeasurements = false;
 		// this is for example required for Grisudet sims, when low gains are read from
@@ -1088,7 +1087,6 @@ void VReadRunParameter::test_and_adjustParams()
 			fRunPara->fcalibrationfile = "";
 		}
 		fRunPara->fDBTracking = false;
-		//        fRunPara->fuseDB = false;
 		fRunPara->fcalibrationrun = true;
 	}
 	if( fRunPara->frunmode != 1 && fRunPara->frunmode != 6 )
@@ -1191,97 +1189,7 @@ void VReadRunParameter::test_and_adjustParams()
 	// (some values can be overwritten by the command line)
 	if( fRunPara->fuseDB )
 	{
-		VDBRunInfo i_DBinfo( fRunPara->frunnumber, fRunPara->getDBServer(), fRunPara->fNTelescopes );
-		if( i_DBinfo.isGood() )
-		{
-			fRunPara->fTargetName = i_DBinfo.getTargetName();
-			// DB coordinates are in J2000
-			fRunPara->fTargetDec = i_DBinfo.getTargetDec();
-			fRunPara->fTargetRA = i_DBinfo.getTargetRA();
-			if( fWobbleNorth_overwriteDB < -9998. )
-			{
-				fRunPara->fWobbleNorth = i_DBinfo.getWobbleNorth();
-			}
-			else
-			{
-				fRunPara->fWobbleNorth = fWobbleNorth_overwriteDB;
-				cout << "VReadRunParameter::test_and_adjustParams() info: overwriting DB wobble north (";
-				cout << i_DBinfo.getWobbleNorth() << " deg)";
-				cout << "with command line value: " << fWobbleNorth_overwriteDB << " deg" << endl;
-			}
-			if( fWobbleEast_overwriteDB < -9998. )
-			{
-				fRunPara->fWobbleEast = i_DBinfo.getWobbleEast();
-			}
-			else
-			{
-				fRunPara->fWobbleEast = fWobbleEast_overwriteDB;
-				cout << "VReadRunParameter::test_and_adjustParams() info: overwriting DB wobble east (";
-				cout << i_DBinfo.getWobbleEast() << " deg)";
-				cout << "with command line value: " << fWobbleEast_overwriteDB << " deg" << endl;
-			}
-			fRunPara->fDBRunType = i_DBinfo.getRunType();
-			fRunPara->fDBRunStartTimeSQL = i_DBinfo.getDataStartTimeSQL();
-			fRunPara->fDBRunStoppTimeSQL = i_DBinfo.getDataStoppTimeSQL();
-			fRunPara->fDBDataStartTimeMJD = i_DBinfo.getDataStartTimeMJD();
-			fRunPara->fDBDataStoppTimeMJD = i_DBinfo.getDataStoppTimeMJD();
-			fRunPara->fDBDataStartTimeSecOfDay = i_DBinfo.getDataStartTime();
-			fRunPara->fDBDataStoppTimeSecOfDay = i_DBinfo.getDataStoppTime();
-			fRunPara->fRunDuration = ( float )i_DBinfo.getDuration();
-			if( fTelToAna == 0 )
-			{
-				fTelToAna = i_DBinfo.getTelToAna();
-			}
-			// get source file from run number (if run number is given and no sourcefile)
-			if( fRunPara->fsourcefile.size() < 1 )
-			{
-				char iname[5000];
-				// set raw data directories
-				if( fRunPara->getDirectory_VBFRawData().size() > 0 )
-				{
-					sprintf( iname, "%s/d%d/%d.cvbf", fRunPara->getDirectory_VBFRawData().c_str(), i_DBinfo.getRunDate(), fRunPara->frunnumber );
-					if( gSystem->AccessPathName( iname ) )
-					{
-						sprintf( iname, "%s/data/d%d/%d.cvbf", fRunPara->getDirectory_VBFRawData().c_str(), i_DBinfo.getRunDate(), fRunPara->frunnumber );
-					}
-				}
-				else
-				{
-					sprintf( iname, "data/d%d/%d.cvbf", i_DBinfo.getRunDate(), fRunPara->frunnumber );
-					cout << iname << endl;
-				}
-				fRunPara->fsourcefile = iname;
-			}
-			
-			// get laser runs
-			if( fRunPara->frunmode != 2 && fRunPara->frunmode != 5 )
-			{
-				vector< unsigned int > iL = i_DBinfo.getLaserRun();
-				if( iL.size() != fRunPara->fNTelescopes )
-				{
-					cout << "VReadRunParameter::test_and_adjustParams() error: list of laser file has wrong length ";
-					cout << iL.size() << "\t" << fRunPara->fNTelescopes << endl;
-					exit( EXIT_FAILURE );
-				}
-				else
-				{
-					for( unsigned int i = 0; i < iL.size(); i++ )
-					{
-						fRunPara->fGainFileNumber[i] = ( int )iL[i];
-						fRunPara->fTOffFileNumber[i] = ( int )iL[i];
-					}
-				}
-			}
-			
-			i_DBinfo.print();
-		}
-		else
-		{
-			cout << endl;
-			cout << "FATAL ERROR: cannot connect to VERITAS database" << endl;
-			cout << "exiting..." << endl;
-			exit( EXIT_FAILURE );
-		}
+		read_db_runinfo();
 	}
 	if( !readEpochsAndAtmospheres() )
 	{
@@ -1314,15 +1222,6 @@ void VReadRunParameter::test_and_adjustParams()
 			cout << "error: cannot read gzipped or bzipped files" << endl;
 			exit( EXIT_FAILURE );
 		}
-	}
-	
-	//////////////////////////////////////////////////////////////////////////////////////////////////////////
-	// can't apply T-point corrections to pointing monitor data
-	if( fRunPara->fDBTrackingCorrections.size() > 0 && fRunPara->fPMTextFileDirectory.size() > 0 )
-	{
-		cout << "error: can't apply T-point corrections to pointing monitor data" << endl;
-		cout << "exiting..." << endl;
-		exit( -1 );
 	}
 	
 	// switch of display in calibration and dst mode
@@ -1692,7 +1591,7 @@ void VReadRunParameter::isCompiledWithDB()
 	cout << endl;
 	cout << "       uncomment line 'DBFLAG=-DRUNWITHDB' in Makefile to compile eventdisplay with mysql support" << endl;
 	cout << "#########################################################################################" << endl;
-	exit( 0 );
+	exit( EXIT_FAILURE );
 #endif
 }
 
@@ -1734,6 +1633,7 @@ bool VReadRunParameter::getRunParametersFromDST()
 		fRunPara->fIsMC = 0;
 	}
 	fRunPara->fuseDB = false;
+	fRunPara->fDBTextDirectory = "";
 	fRunPara->fDBTracking = false;
 	VEvndispRunParameter* iV = ( VEvndispRunParameter* )iF.Get( "runparameterDST" );
 	if( !iV )
@@ -1943,4 +1843,102 @@ bool VReadRunParameter::readEpochsAndAtmospheres()
 	}
 	
 	return true;
+}
+
+void VReadRunParameter::read_db_runinfo()
+{
+	VDBRunInfo i_DBinfo( fRunPara->frunnumber,
+						 fRunPara->getDBServer(),
+						 fRunPara->fNTelescopes,
+						 fRunPara->fDBTextDirectory );
+	if( i_DBinfo.isGood() )
+	{
+		fRunPara->fTargetName = i_DBinfo.getTargetName();
+		// DB coordinates are in J2000
+		fRunPara->fTargetDec = i_DBinfo.getTargetDec();
+		fRunPara->fTargetRA = i_DBinfo.getTargetRA();
+		if( fWobbleNorth_overwriteDB < -9998. )
+		{
+			fRunPara->fWobbleNorth = i_DBinfo.getWobbleNorth();
+		}
+		else
+		{
+			fRunPara->fWobbleNorth = fWobbleNorth_overwriteDB;
+			cout << "VReadRunParameter::test_and_adjustParams() info: overwriting DB wobble north (";
+			cout << i_DBinfo.getWobbleNorth() << " deg)";
+			cout << "with command line value: " << fWobbleNorth_overwriteDB << " deg" << endl;
+		}
+		if( fWobbleEast_overwriteDB < -9998. )
+		{
+			fRunPara->fWobbleEast = i_DBinfo.getWobbleEast();
+		}
+		else
+		{
+			fRunPara->fWobbleEast = fWobbleEast_overwriteDB;
+			cout << "VReadRunParameter::test_and_adjustParams() info: overwriting DB wobble east (";
+			cout << i_DBinfo.getWobbleEast() << " deg)";
+			cout << "with command line value: " << fWobbleEast_overwriteDB << " deg" << endl;
+		}
+		fRunPara->fDBRunType = i_DBinfo.getRunType();
+		fRunPara->fDBRunStartTimeSQL = i_DBinfo.getDataStartTimeSQL();
+		fRunPara->fDBRunStoppTimeSQL = i_DBinfo.getDataStoppTimeSQL();
+		fRunPara->fDBDataStartTimeMJD = i_DBinfo.getDataStartTimeMJD();
+		fRunPara->fDBDataStoppTimeMJD = i_DBinfo.getDataStoppTimeMJD();
+		fRunPara->fDBDataStartTimeSecOfDay = i_DBinfo.getDataStartTime();
+		fRunPara->fDBDataStoppTimeSecOfDay = i_DBinfo.getDataStoppTime();
+		fRunPara->fRunDuration = ( float )i_DBinfo.getDuration();
+		if( fTelToAna == 0 )
+		{
+			fTelToAna = i_DBinfo.getTelToAna();
+		}
+		// get source file from run number (if run number is given and no sourcefile)
+		if( fRunPara->fsourcefile.size() < 1 )
+		{
+			char iname[5000];
+			// set raw data directories
+			if( fRunPara->getDirectory_VBFRawData().size() > 0 )
+			{
+				sprintf( iname, "%s/d%d/%d.cvbf", fRunPara->getDirectory_VBFRawData().c_str(), i_DBinfo.getRunDate(), fRunPara->frunnumber );
+				if( gSystem->AccessPathName( iname ) )
+				{
+					sprintf( iname, "%s/data/d%d/%d.cvbf", fRunPara->getDirectory_VBFRawData().c_str(), i_DBinfo.getRunDate(), fRunPara->frunnumber );
+				}
+			}
+			else
+			{
+				sprintf( iname, "data/d%d/%d.cvbf", i_DBinfo.getRunDate(), fRunPara->frunnumber );
+				cout << iname << endl;
+			}
+			fRunPara->fsourcefile = iname;
+		}
+		
+		// get laser runs
+		if( fRunPara->frunmode != 2 && fRunPara->frunmode != 5 )
+		{
+			vector< unsigned int > iL = i_DBinfo.getLaserRun();
+			if( iL.size() != fRunPara->fNTelescopes )
+			{
+				cout << "VReadRunParameter::test_and_adjustParams() error: list of laser file has wrong length ";
+				cout << iL.size() << "\t" << fRunPara->fNTelescopes << endl;
+				exit( EXIT_FAILURE );
+			}
+			else
+			{
+				for( unsigned int i = 0; i < iL.size(); i++ )
+				{
+					fRunPara->fGainFileNumber[i] = ( int )iL[i];
+					fRunPara->fTOffFileNumber[i] = ( int )iL[i];
+				}
+			}
+		}
+		
+		i_DBinfo.print();
+	}
+	else
+	{
+		cout << endl;
+		cout << "FATAL ERROR: cannot connect to VERITAS database" << endl;
+		cout << "exiting..." << endl;
+		exit( EXIT_FAILURE );
+	}
 }

--- a/src/VSQLTextFileReader.cpp
+++ b/src/VSQLTextFileReader.cpp
@@ -1,0 +1,200 @@
+/* VSQLTextFileReader
+ *
+ * simple reader for SQL text files
+ *
+ */
+
+#include "VSQLTextFileReader.h"
+
+VSQLTextFileReader::VSQLTextFileReader( string iSQLFile )
+{
+	fIsGood = false;
+	readSQLFile( iSQLFile );
+}
+
+VSQLTextFileReader::VSQLTextFileReader(
+	string iSQLFileDirectory,
+	unsigned irunnumber,
+	string iSQLFileType,
+	unsigned int iTelID )
+{
+	fIsGood = false;
+	
+	string iSQLFile =
+		iSQLFileDirectory + "/" +
+		to_string( irunnumber / 10000 ) + "/" +
+		to_string( irunnumber ) + "/" +
+		to_string( irunnumber ) + "." +
+		iSQLFileType;
+	if( iTelID < 9999 )
+	{
+		iSQLFile += "_TEL" + to_string( iTelID );
+	}
+	readSQLFile( iSQLFile );
+}
+
+
+void VSQLTextFileReader::readSQLFile( string iSQLFile )
+{
+	cout << "Reading SQLText data from " << iSQLFile << endl;
+	
+	ifstream sql_file;
+	sql_file.open( iSQLFile.c_str() );
+	if( sql_file.fail() )
+	{
+		cout << "Error opening SQLText data from " << iSQLFile << endl;
+		exit( EXIT_FAILURE );
+	}
+	
+	string line;
+	unsigned int z = 0;
+	vector< string > temp_string;
+	vector< string > key_vector;
+	while( sql_file.good() )
+	{
+		getline( sql_file, line );
+		istringstream ss( line );
+		if( line.size() ==  0 )
+		{
+			continue;
+		}
+		string temp;
+		if( z == 0 )
+		{
+			while( ss.good() )
+			{
+				getline( ss, temp, '|' );
+				fData[temp] = temp_string;
+				key_vector.push_back( temp );
+			}
+		}
+		else
+		{
+			unsigned int counter = 0;
+			while( ss.good() )
+			{
+				getline( ss, temp, '|' );
+				if( counter < key_vector.size() && fData.find( key_vector[counter] ) != fData.end() )
+				{
+					fData[key_vector[counter]].push_back( temp );
+				}
+				else
+				{
+					cout << "\t warning: inconsistent column data" << endl;
+				}
+				counter++;
+			}
+		}
+		z++;
+	};
+	sql_file.close();
+	
+	fIsGood = true;
+}
+
+string VSQLTextFileReader::getValue_from_key( string iKey )
+{
+	if( fData.find( iKey ) != fData.end() && fData[iKey].size() > 0 )
+	{
+		return fData[iKey][0];
+	}
+	return "";
+}
+
+vector< string > VSQLTextFileReader::getValueVector_from_key( string iKey )
+{
+	if( fData.find( iKey ) != fData.end() )
+	{
+		return fData[iKey];
+	}
+	return vector< string >();
+}
+
+vector< unsigned int > VSQLTextFileReader::getValueVector_from_key_as_integer( string iKey )
+{
+	vector< unsigned int > itemp;
+	if( fData.find( iKey ) != fData.end() )
+	{
+		for( unsigned int i = 0; i < fData[iKey].size(); i++ )
+		{
+			if( fData[iKey][i].size() > 0 )
+			{
+				itemp.push_back( atoi( fData[iKey][i].c_str() ) );
+			}
+			else
+			{
+				itemp.push_back( 0 );
+			}
+		}
+	}
+	return itemp;
+}
+
+vector< double > VSQLTextFileReader::getValueVector_from_key_as_double( string iKey )
+{
+	vector< double > itemp;
+	if( fData.find( iKey ) != fData.end() )
+	{
+		for( unsigned int i = 0; i < fData[iKey].size(); i++ )
+		{
+			if( fData[iKey][i].size() > 0 )
+			{
+				itemp.push_back( atof( fData[iKey][i].c_str() ) );
+			}
+			else
+			{
+				itemp.push_back( 0. );
+			}
+		}
+	}
+	return itemp;
+}
+
+string VSQLTextFileReader::getValue_from_key( string iKey, string iSearchKey, string iValue )
+{
+	if( fData.find( iSearchKey ) != fData.end() && fData.find( iKey ) != fData.end() )
+	{
+		for( unsigned int i = 0; i < fData[iSearchKey].size(); i++ )
+		{
+			if( fData[iSearchKey][i] == iValue )
+			{
+				return fData[iKey][i];
+			}
+		}
+	}
+	return "";
+}
+
+bool VSQLTextFileReader::checkDataVectorsForSameLength()
+{
+	unsigned int iLength = 0;
+	for( map<string, vector< string > >::iterator it = fData.begin(); it != fData.end(); ++it )
+	{
+		if( iLength == 0 )
+		{
+			iLength = it->second.size();
+		}
+		else
+		{
+			if( iLength != it->second.size() )
+			{
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+
+void VSQLTextFileReader::printData()
+{
+	for( map<string, vector< string > >::iterator it = fData.begin(); it != fData.end(); ++it )
+	{
+		cout << it->first << ": ";
+		for( unsigned int i = 0; i < it->second.size(); i++ )
+		{
+			cout << it->second[i] << "   ";
+		}
+		cout << endl;
+	}
+}

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -358,23 +358,22 @@ bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
 	fShower_Xoffset = xoff;
 	fShower_Yoffset = yoff;
 	
-	// ze / az
-	double ze = 0.;
+	double el = 0.;
 	double az = 0.;
 	VAstronometry::vlaDtp2s( -1.* fShower_Xoffset * TMath::DegToRad(),
 							 fShower_Yoffset * TMath::DegToRad(),
 							 fTelAzimuth * TMath::DegToRad(),
 							 fTelElevation * TMath::DegToRad(),
-							 &az, &ze );
-	az *= TMath::RadToDeg();
-	ze = 90. - ze * TMath::RadToDeg();
-	
-	if( TMath::IsNaN( ze ) )
+							 &az, &el );
+	if( TMath::IsNaN( el ) )
 	{
 		fShower_Ze = -99999.;
 	}
-	fShower_Ze = ze;
-	fShower_Az = VAstronometry::vlaDranrm( az * TMath::DegToRad() ) * TMath::RadToDeg();
+	else
+	{
+		fShower_Ze = 90. - el * TMath::RadToDeg();
+	}
+	fShower_Az = VAstronometry::vlaDranrm( az ) * TMath::RadToDeg();
 	
 	return true;
 }

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -518,30 +518,18 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 			flength[i] = ftpars[i]->length;
 			ftgrad_x[i] = ftpars[i]->tgrad_x;
 			
+			fcen_x[i] = ftpars[i]->cen_x;
+			fcen_y[i] = ftpars[i]->cen_y;
+			fcosphi[i] = ftpars[i]->cosphi;
+			fsinphi[i] = ftpars[i]->sinphi;
+			fpointing_dx[i] = 0.;
+			fpointing_dy[i] = 0.;
 			if( i < fpointingCorrections.size() && fpointingCorrections[i]
 					&& fpointingCorrections[i]->is_initialized() )
 			{
 				fpointingCorrections[i]->getEntry( fEventCounter );
-				fcen_x[i] = fpointingCorrections[i]->getCorrected_cen_x( ftpars[i]->cen_x );
-				fcen_y[i] = fpointingCorrections[i]->getCorrected_cen_y( ftpars[i]->cen_y );
-				if( ftpars[i]->has_sdevxy() )
-				{
-					float phi = fpointingCorrections[i]->getCorrected_phi(
-									ftpars[i]->cen_x,
-									ftpars[i]->cen_y,
-									ftpars[i]->f_d,
-									ftpars[i]->f_s,
-									ftpars[i]->f_sdevxy );
-					fcosphi[i] = cos( phi );
-					fsinphi[i] = sin( phi );
-				}
-			}
-			else
-			{
-				fcen_x[i] = ftpars[i]->cen_x;
-				fcen_y[i] = ftpars[i]->cen_y;
-				fcosphi[i] = ftpars[i]->cosphi;
-				fsinphi[i] = ftpars[i]->sinphi;
+				fpointing_dx[i] = fpointingCorrections[i]->getPointErrorX();
+				fpointing_dy[i] = fpointingCorrections[i]->getPointErrorY();
 			}
 			
 			if( fsize[i] > SizeSecondMax_temp )
@@ -681,7 +669,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 		fDispAnalyzerDirection->setQualityCuts( fSSR_NImages_min, fSSR_AxesAngles_min,
 												fTLRunParameter->fmaxdist,
 												fTLRunParameter->fmaxloss );
-		fDispAnalyzerDirection->calculateMeanDirection(
+		fDispAnalyzerDirection->calculateMeanDispDirection(
 			getNTel(),
 			fArrayPointing_Elevation, fArrayPointing_Azimuth,
 			fTel_type,
@@ -694,7 +682,8 @@ void VTableLookupDataHandler::doStereoReconstruction()
 			getWeight(),
 			i_SR.fShower_Xoffset, i_SR.fShower_Yoffset,
 			iDispError,
-			fmeanPedvar_ImageT );
+			fmeanPedvar_ImageT,
+			fpointing_dx, fpointing_dy );
 		// reconstructed direction by disp method:
 		fXoff = fDispAnalyzerDirection->getXcoordinate_disp();
 		fYoff = fDispAnalyzerDirection->getYcoordinate_disp();
@@ -1685,7 +1674,9 @@ bool VTableLookupDataHandler::terminate( TNamed* iM )
 		// copy TTree 'pointingDataReduced' and 'deadPixelRegistry' from evndisp.<>.root to mscw.<>.root
 		if( finputfile.size() > 1 && !fIsMC )
 		{
-			cout << "Warning, VTableLookupDataHandler->finputfile.size() isn't 1, not sure which input file to copy TTree 'pointingDataReduced' from, copying from file finputfile[0]:" << finputfile[0] << endl;
+			cout << "Warning, VTableLookupDataHandler->finputfile.size() isn't 1,";
+			cout << " not sure which input file to copy TTree 'pointingDataReduced'";
+			cout << " from, copying from file finputfile[0]:" << finputfile[0] << endl;
 		}
 		// not sure why we don't want to do this for MC
 		if( finputfile.size() > 0 && !fIsMC )
@@ -2036,6 +2027,8 @@ void VTableLookupDataHandler::resetImageParameters( unsigned int i )
 	fasym[i] = 0.;
 	fcen_x[i] = 0.;
 	fcen_y[i] = 0.;
+	fpointing_dx[i] = 0.;
+	fpointing_dy[i] = 0.;
 	fcosphi[i] = 0.;
 	fsinphi[i] = 0.;
 	fmax1[i] = 0.;
@@ -2238,6 +2231,8 @@ void VTableLookupDataHandler::resetAll()
 		fasym[i] = 0.;
 		fcen_x[i] = 0.;
 		fcen_y[i] = 0.;
+		fpointing_dx[i] = 0.;
+		fpointing_dy[i] = 0.;
 		fcosphi[i] = 0.;
 		fsinphi[i] = 0.;
 		ftgrad_x[i] = 0.;

--- a/src/printMJD.cpp
+++ b/src/printMJD.cpp
@@ -1,0 +1,30 @@
+/*! \file printMJD
+ *
+ *  print MJD from SQL string
+ *
+ */
+
+#include <iomanip>
+#include <iostream>
+
+#include "VSkyCoordinatesUtilities.h"
+
+using namespace std;
+
+int main( int argc, char* argv[] )
+{
+	if( argc != 2 )
+	{
+		cout << "printMJD <SQL date>" << endl;
+		cout << endl;
+		cout << "print MJD from sql string" << endl;
+		exit( EXIT_SUCCESS );
+	}
+	string iSQLData = argv[1];
+	
+	double mjd = 0.;
+	double sec_of_day = 0;
+	VSkyCoordinatesUtilities::getMJD_from_SQLstring( iSQLData, mjd, sec_of_day );
+	
+	cout << setprecision( 18 ) << mjd + sec_of_day / 86400. << endl;
+}


### PR DESCRIPTION
Changes related to v490-alpha.3

# dispBDT angular resolution

- add correct addition of VPM pointing monitor correction to dispBDT direction reconstruction

# Writing of image/border pixel lists on evndisp stage

Option `-writeimagepixellist` to evndisp allows to write out list of pixel (with integrated charge and timing) surviving the image cleaning.

This option increases the output files of evndisp by approximately a factor 2.5-3. It is therefore switched off by default.

Written are image, border pixels, and one additional ring of pixels around them.

Written the pars trees:
```
PixelListN : PixelListN/i
PixelID   : PixelID[PixelListN]/i 
PixelType : PixelType[PixelListN]/i 
PixelIntensity : PixelIntensity[PixelListN]/F
PixelTimingT0 : PixelTimingT0[PixelListN]/F 
```

PixelType indicates the following:
+    PixelType == 1: image pixel
+    PixelType == 2: border pixel
+    PixelType == 3: neighbour pixel to image/border

# Use DB text files instead of direct query to VERITAS data base

New functionality to read DB text files. This allows faster parallel processing of many runs without opening up too many connections to the VERITAS database. Requires reading of DB information using the scripts available in the `db_scripts` directory of `Eventdisplay_AnalysisScripts_VTS`. Possibly also a step to remove the ROOT-mysql dependency and allow for easier compilation.

# Others

- DOI badge