### PR TITLE
Add functionality to write list of pixels after cleaning

### DIFF
--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -137,7 +137,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		bool fNoCalibNoPb;                        // if true, when no information for gain and toff can be found, the analysis is done filling thenm with 1 and 0 respectively (in VCalibrator)
 		bool fNextDayGainHack;			  //if true, and > 100 channels in one telescope have gain=0, all gains in that tel will be set to 1; gains won't be tested in the dead channel finder.
 		bool fWriteExtraCalibTree;		  // write additional tree into .gain.root file with channel charges/monitor charge/nHiLo for each event
-        bool fWriteImagePixelList;        // write image pixel list to tpars tree
+		bool fWriteImagePixelList;        // write image pixel list to tpars tree
 		string fLowGainCalibrationFile;           // file with file name for low-gain calibration
 		int fNCalibrationEvents;                  // events to be used for calibration
 		float faverageTZeroFiducialRadius;        // fiducial radius for average tzero calculation (DST), in fraction of FOV

--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -137,6 +137,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		bool fNoCalibNoPb;                        // if true, when no information for gain and toff can be found, the analysis is done filling thenm with 1 and 0 respectively (in VCalibrator)
 		bool fNextDayGainHack;			  //if true, and > 100 channels in one telescope have gain=0, all gains in that tel will be set to 1; gains won't be tested in the dead channel finder.
 		bool fWriteExtraCalibTree;		  // write additional tree into .gain.root file with channel charges/monitor charge/nHiLo for each event
+        bool fWriteImagePixelList;        // write image pixel list to tpars tree
 		string fLowGainCalibrationFile;           // file with file name for low-gain calibration
 		int fNCalibrationEvents;                  // events to be used for calibration
 		float faverageTZeroFiducialRadius;        // fiducial radius for average tzero calculation (DST), in fraction of FOV
@@ -320,6 +321,6 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 			return fuseDB;
 		}
 		
-		ClassDef( VEvndispRunParameter, 2001 ); //(increase this number)
+		ClassDef( VEvndispRunParameter, 2002 ); //(increase this number)
 };
 #endif

--- a/inc/VImageAnalyzerData.h
+++ b/inc/VImageAnalyzerData.h
@@ -81,19 +81,19 @@ class VImageAnalyzerData
 		vector<bool> fImage;
 		vector<int> fImageUser;                   //!< channels which are enabled/disables by the user
 		vector<bool> fBorder;
-		vector<bool> fTrigger;                    //!< MS: pixels selected by trigger algorithm
+		vector<bool> fTrigger;                    //!< pixels selected by trigger algorithm
 		vector<bool> fBrightNonImage;             //!< pixel above non image threshold
 		vector<bool> fImageBorderNeighbour;       //!< image and border pixel plus their neighbours
 		// time cleaning
-		vector<int> fClusterNpix;                 //!< HP: numer of pixels in cluster
-		vector<int> fClusterID;                   //!< HP: cluster ID
-		int fMainClusterID;                       //!< HP: main cluster ID
-		vector<double> fClusterSize;              //!< HP: size of the cluster
-		vector<double> fClusterTime;              //!< HP: weighted mean time of the cluster
-		vector<double> fClusterCenx;              //!< HP: cenX of the cluster
-		vector<double> fClusterCeny;              //!< HP: cenY of the cluster
-		int fncluster_cleaned;                    //!< HP: number of clusters
-		int fncluster_uncleaned;                  //!< HP: number of clusters before cluster rejection
+		vector<int> fClusterNpix;                 //!< number of pixels in cluster
+		vector<int> fClusterID;                   //!< cluster ID
+		int fMainClusterID;                       //!< main cluster ID
+		vector<double> fClusterSize;              //!< size of the cluster
+		vector<double> fClusterTime;              //!< weighted mean time of the cluster
+		vector<double> fClusterCenx;              //!< cenX of the cluster
+		vector<double> fClusterCeny;              //!< cenY of the cluster
+		int fncluster_cleaned;                    //!< number of clusters
+		int fncluster_uncleaned;                  //!< number of clusters before cluster rejection
 		// correlation cleaning
 		vector<double> fCorrelationCoefficient;  // correlation coefficient
 		// time since run start
@@ -119,7 +119,7 @@ class VImageAnalyzerData
 		vector< unsigned int > iDummyVectorUI;
 		
 		VImageAnalyzerData( unsigned int iTelID, unsigned int iShortTree = 0,
-							bool bCalibration = false );
+                            bool bCalibration = false, bool bWriteImagePixelList = false );
 		~VImageAnalyzerData() {}
 		
 		void                     fillPulseSum( unsigned int, double, bool );

--- a/inc/VImageAnalyzerData.h
+++ b/inc/VImageAnalyzerData.h
@@ -119,7 +119,7 @@ class VImageAnalyzerData
 		vector< unsigned int > iDummyVectorUI;
 		
 		VImageAnalyzerData( unsigned int iTelID, unsigned int iShortTree = 0,
-                            bool bCalibration = false, bool bWriteImagePixelList = false );
+							bool bCalibration = false, bool bWriteImagePixelList = false );
 		~VImageAnalyzerData() {}
 		
 		void                     fillPulseSum( unsigned int, double, bool );

--- a/inc/VImageParameter.h
+++ b/inc/VImageParameter.h
@@ -168,7 +168,6 @@ class VImageParameter
 		unsigned int PixelType[VDST_MAXCHANNELS];
 		float PixelIntensity[VDST_MAXCHANNELS];
 		float PixelTimingT0[VDST_MAXCHANNELS];
-		float PixelPE[VDST_MAXCHANNELS];
 		
 		vector< float > fImageBorderPixelPosition_x;              //! list of image+border pixel
 		vector< float > fImageBorderPixelPosition_y;              //! list of image+border pixel

--- a/inc/VImageParameter.h
+++ b/inc/VImageParameter.h
@@ -7,6 +7,8 @@
 
 #include <iostream>
 
+#include "VGlobalRunParameter.h"
+
 using namespace std;
 
 class VImageParameter
@@ -15,6 +17,7 @@ class VImageParameter
 		TTree* tpars;
 		bool fMC;
 		unsigned int fShortTree;                 // if set, only a subset of the parameters are written to the tree of parameters
+        bool fWriteNImagePixels;
 		
 	public:
 		// global parameters
@@ -159,10 +162,18 @@ class VImageParameter
 		float signal;
 		float dsignal;                            //!< error in signal (normalisation parameter for fit)
 		
+        // image / border list
+        unsigned int PixelListN;
+        unsigned int PixelID[VDST_MAXCHANNELS];
+        unsigned int PixelType[VDST_MAXCHANNELS];
+        float PixelIntensity[VDST_MAXCHANNELS];
+        float PixelTimingT0[VDST_MAXCHANNELS];
+        float PixelPE[VDST_MAXCHANNELS];
+        
 		vector< float > fImageBorderPixelPosition_x;              //! list of image+border pixel
 		vector< float > fImageBorderPixelPosition_y;              //! list of image+border pixel
 		
-		VImageParameter( unsigned int iShortTree = 0 );
+        VImageParameter( unsigned int iShortTree = 0, bool iWriteNImagePixels = false );
 		~VImageParameter();
 		void fill();
 		TTree* getTree()
@@ -175,6 +186,7 @@ class VImageParameter
 		{
 			return fMC;
 		}
+        bool isWriteNImagePixels() { return fWriteNImagePixels; }
 		void printParameters();
 		void reset( unsigned int resetLevel = 0 );
 		void setImageBorderPixelPosition( vector< float > iImageBorderPixelPosition_x, vector< float > iImageBorderPixelPosition_y );

--- a/inc/VImageParameter.h
+++ b/inc/VImageParameter.h
@@ -17,7 +17,7 @@ class VImageParameter
 		TTree* tpars;
 		bool fMC;
 		unsigned int fShortTree;                 // if set, only a subset of the parameters are written to the tree of parameters
-        bool fWriteNImagePixels;
+		bool fWriteNImagePixels;
 		
 	public:
 		// global parameters
@@ -162,18 +162,18 @@ class VImageParameter
 		float signal;
 		float dsignal;                            //!< error in signal (normalisation parameter for fit)
 		
-        // image / border list
-        unsigned int PixelListN;
-        unsigned int PixelID[VDST_MAXCHANNELS];
-        unsigned int PixelType[VDST_MAXCHANNELS];
-        float PixelIntensity[VDST_MAXCHANNELS];
-        float PixelTimingT0[VDST_MAXCHANNELS];
-        float PixelPE[VDST_MAXCHANNELS];
-        
+		// image / border list
+		unsigned int PixelListN;
+		unsigned int PixelID[VDST_MAXCHANNELS];
+		unsigned int PixelType[VDST_MAXCHANNELS];
+		float PixelIntensity[VDST_MAXCHANNELS];
+		float PixelTimingT0[VDST_MAXCHANNELS];
+		float PixelPE[VDST_MAXCHANNELS];
+		
 		vector< float > fImageBorderPixelPosition_x;              //! list of image+border pixel
 		vector< float > fImageBorderPixelPosition_y;              //! list of image+border pixel
 		
-        VImageParameter( unsigned int iShortTree = 0, bool iWriteNImagePixels = false );
+		VImageParameter( unsigned int iShortTree = 0, bool iWriteNImagePixels = false );
 		~VImageParameter();
 		void fill();
 		TTree* getTree()
@@ -186,7 +186,10 @@ class VImageParameter
 		{
 			return fMC;
 		}
-        bool isWriteNImagePixels() { return fWriteNImagePixels; }
+		bool isWriteNImagePixels()
+		{
+			return fWriteNImagePixels;
+		}
 		void printParameters();
 		void reset( unsigned int resetLevel = 0 );
 		void setImageBorderPixelPosition( vector< float > iImageBorderPixelPosition_x, vector< float > iImageBorderPixelPosition_y );

--- a/inc/VImageParameterCalculation.h
+++ b/inc/VImageParameterCalculation.h
@@ -76,8 +76,6 @@ class VImageParameterCalculation : public TObject
 		
 		//Hough transform
 		void houghInitialization(); 				//Initialize the Hough transform class
-		void houghMuonRingFinder();                 //!< fit a single ring to the image to look for muons
-		void houghSizeInMuonRing();                 //! calculate the brightness of the muon ring
 		void houghMuonPixelDistribution();          //!< determine the distribution of pixels in the image
 		
 		void calcTriggerParameters( vector<bool> fTrigger );                                   //!< MS: calculate trigger-level image parameters
@@ -124,6 +122,8 @@ class VImageParameterCalculation : public TObject
 		{
 			return fDetectorGeometry;
 		}
+        //!< fill image/border list (optional)
+        void fillImageBorderPixelTree();
 		//!< return value of 2d-gaus at channel iChannel
 		double getFitValue( unsigned int iChannel, double, double, double, double, double, double );
 		//!< set the detector geometry

--- a/inc/VImageParameterCalculation.h
+++ b/inc/VImageParameterCalculation.h
@@ -122,8 +122,8 @@ class VImageParameterCalculation : public TObject
 		{
 			return fDetectorGeometry;
 		}
-        //!< fill image/border list (optional)
-        void fillImageBorderPixelTree();
+		//!< fill image/border list (optional)
+		void fillImageBorderPixelTree();
 		//!< return value of 2d-gaus at channel iChannel
 		double getFitValue( unsigned int iChannel, double, double, double, double, double, double );
 		//!< set the detector geometry

--- a/src/VEventLoop.cpp
+++ b/src/VEventLoop.cpp
@@ -613,7 +613,7 @@ void VEventLoop::initializeAnalyzers()
 			fAnaData.push_back( new VImageAnalyzerData( i, fRunPar->fShortTree, ( fRunMode == R_PED || fRunMode == R_PEDLOW ||
 								fRunMode == R_GTO || fRunMode == R_GTOLOW ||
 								fRunMode == R_TZERO || fRunMode == R_TZEROLOW ),
-                                getRunParameter()->fWriteImagePixelList ) );
+								getRunParameter()->fWriteImagePixelList ) );
 			int iseed = fRunPar->fMCNdeadSeed;
 			if( iseed != 0 )
 			{

--- a/src/VEventLoop.cpp
+++ b/src/VEventLoop.cpp
@@ -612,7 +612,8 @@ void VEventLoop::initializeAnalyzers()
 			setTelID( i );
 			fAnaData.push_back( new VImageAnalyzerData( i, fRunPar->fShortTree, ( fRunMode == R_PED || fRunMode == R_PEDLOW ||
 								fRunMode == R_GTO || fRunMode == R_GTOLOW ||
-								fRunMode == R_TZERO || fRunMode == R_TZEROLOW ) ) );
+								fRunMode == R_TZERO || fRunMode == R_TZEROLOW ),
+                                getRunParameter()->fWriteImagePixelList ) );
 			int iseed = fRunPar->fMCNdeadSeed;
 			if( iseed != 0 )
 			{

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -230,7 +230,7 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	ffillhistos = false;                          // obsolete
 	foutputfileName = "";
 	fWriteExtraCalibTree = false;
-    fWriteImagePixelList = false;
+	fWriteImagePixelList = false;
 	// MC parameters
 	// offset in telescope numbering (0 for old grisudet version (<3.0.0))
 	ftelescopeNOffset = 1;

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -732,10 +732,10 @@ void VEvndispRunParameter::print( int iEv )
 	{
 		cout << endl << "shortened tree output " << endl;
 	}
-    if( fWriteImagePixelList )
-    {
-        cout << "(add image/border pixel list to output tree)" << endl;
-    }
+	if( fWriteImagePixelList )
+	{
+		cout << "(add image/border pixel list to output tree)" << endl;
+	}
 	
 	// print analysis parameters
 	if( iEv == 2 )

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -230,6 +230,7 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	ffillhistos = false;                          // obsolete
 	foutputfileName = "";
 	fWriteExtraCalibTree = false;
+    fWriteImagePixelList = false;
 	// MC parameters
 	// offset in telescope numbering (0 for old grisudet version (<3.0.0))
 	ftelescopeNOffset = 1;

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -732,6 +732,10 @@ void VEvndispRunParameter::print( int iEv )
 	{
 		cout << endl << "shortened tree output " << endl;
 	}
+    if( fWriteImagePixelList )
+    {
+        cout << "(add image/border pixel list to output tree)" << endl;
+    }
 	
 	// print analysis parameters
 	if( iEv == 2 )

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -182,7 +182,7 @@ void VImageAnalyzer::doAnalysis()
 	}
 	
 	///////////////////////////////////////////////////////////////////////////////////////////
-    // set parameters required for image parameter calculation
+	// set parameters required for image parameter calculation
 	fVImageParameterCalculation->setDetectorGeometry( getDetectorGeometry() );
 	fVImageParameterCalculation->setParameters( getImageParameters() );
 	
@@ -328,8 +328,8 @@ void VImageAnalyzer::fillOutputTree()
 		getAnaHistos()->fillL2DiagnosticTree( getRunNumber(), getTelescopeEventNumber( getTelID() ),
 											  0, 0, getFADCstopTZero(), getFADCstopSums() );
 	}
-    // fill (optionally) image/border tree lists
-    fVImageParameterCalculation->fillImageBorderPixelTree();
+	// fill (optionally) image/border tree lists
+	fVImageParameterCalculation->fillImageBorderPixelTree();
 	
 	// fill some basic run parameters
 	getImageParameters()->fimagethresh = getImageThresh();
@@ -503,7 +503,7 @@ void VImageAnalyzer::initOutput()
 			cout << "ERROR: unable to create eventdisplay output file: " << fRunPar->foutputfileName.c_str() << endl;
 			cout << "exiting..." << endl;
 			cout << endl;
-            exit( EXIT_FAILURE );
+			exit( EXIT_FAILURE );
 		}
 	}
 	
@@ -557,20 +557,20 @@ void VImageAnalyzer::initTrees()
 	// tree versioning numbers used in mscw_energy
 	char i_text[300];
 	sprintf( i_text, "tpars" );
-    ostringstream iSTRText;
-    iSTRText << "Event Parameters (Telescope " << getTelID() + 1;
-    iSTRText << ", VERSION " << fRunPar->getEVNDISP_TREE_VERSION() << ")";
+	ostringstream iSTRText;
+	iSTRText << "Event Parameters (Telescope " << getTelID() + 1;
+	iSTRText << ", VERSION " << fRunPar->getEVNDISP_TREE_VERSION() << ")";
 	if( getRunParameter()->fShortTree )
 	{
-        iSTRText << " (short tree)";
+		iSTRText << " (short tree)";
 	}
-    fVImageParameterCalculation->getParameters()->initTree( i_text, iSTRText.str().c_str(), fReader->isMC(), false, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
+	fVImageParameterCalculation->getParameters()->initTree( i_text, iSTRText.str().c_str(), fReader->isMC(), false, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
 	
 	// for log likelihood method, book a second image parameter tree
 	if( fRunPar->fImageLL )
 	{
 		sprintf( i_text, "lpars" );
-        char i_textTitle[300];
+		char i_textTitle[300];
 		sprintf( i_textTitle, "Event Parameters, loglikelihood (Telescope %d)", getTelID() + 1 );
 		fVImageParameterCalculation->getLLParameters()->initTree( i_text, i_textTitle, fReader->isMC(), true, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
 	}

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -182,7 +182,7 @@ void VImageAnalyzer::doAnalysis()
 	}
 	
 	///////////////////////////////////////////////////////////////////////////////////////////
-	// set parameters for image parameter calculation
+    // set parameters required for image parameter calculation
 	fVImageParameterCalculation->setDetectorGeometry( getDetectorGeometry() );
 	fVImageParameterCalculation->setParameters( getImageParameters() );
 	
@@ -328,12 +328,14 @@ void VImageAnalyzer::fillOutputTree()
 		getAnaHistos()->fillL2DiagnosticTree( getRunNumber(), getTelescopeEventNumber( getTelID() ),
 											  0, 0, getFADCstopTZero(), getFADCstopSums() );
 	}
+    // fill (optionally) image/border tree lists
+    fVImageParameterCalculation->fillImageBorderPixelTree();
 	
 	// fill some basic run parameters
 	getImageParameters()->fimagethresh = getImageThresh();
 	getImageParameters()->fborderthresh = getBorderThresh();
-	getImageParameters()->fncluster_cleaned = getNcluster_cleaned(); // HP
-	getImageParameters()->fncluster_uncleaned = getNcluster_uncleaned(); // HP
+	getImageParameters()->fncluster_cleaned = getNcluster_cleaned();
+	getImageParameters()->fncluster_uncleaned = getNcluster_uncleaned();
 	getImageParameters()->fsumfirst = getSumFirst();
 	getImageParameters()->fsumwindow = getSumWindow();
 	getImageParameters()->fsumwindow_2 = getSumWindow_2();
@@ -501,7 +503,7 @@ void VImageAnalyzer::initOutput()
 			cout << "ERROR: unable to create eventdisplay output file: " << fRunPar->foutputfileName.c_str() << endl;
 			cout << "exiting..." << endl;
 			cout << endl;
-			exit( 0 );
+            exit( EXIT_FAILURE );
 		}
 	}
 	
@@ -554,19 +556,21 @@ void VImageAnalyzer::initTrees()
 	// now book the trees (for MC with additional MC block)
 	// tree versioning numbers used in mscw_energy
 	char i_text[300];
-	char i_textTitle[300];
 	sprintf( i_text, "tpars" );
-	sprintf( i_textTitle, "Event Parameters (Telescope %d, VERSION %d)", getTelID() + 1, fRunPar->getEVNDISP_TREE_VERSION() );
+    ostringstream iSTRText;
+    iSTRText << "Event Parameters (Telescope " << getTelID() + 1;
+    iSTRText << ", VERSION " << fRunPar->getEVNDISP_TREE_VERSION() << ")";
 	if( getRunParameter()->fShortTree )
 	{
-		sprintf( i_textTitle, "%s (short tree)", i_textTitle );
+        iSTRText << " (short tree)";
 	}
-	fVImageParameterCalculation->getParameters()->initTree( i_text, i_textTitle, fReader->isMC(), false, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
+    fVImageParameterCalculation->getParameters()->initTree( i_text, iSTRText.str().c_str(), fReader->isMC(), false, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
 	
 	// for log likelihood method, book a second image parameter tree
 	if( fRunPar->fImageLL )
 	{
 		sprintf( i_text, "lpars" );
+        char i_textTitle[300];
 		sprintf( i_textTitle, "Event Parameters, loglikelihood (Telescope %d)", getTelID() + 1 );
 		fVImageParameterCalculation->getLLParameters()->initTree( i_text, i_textTitle, fReader->isMC(), true, fRunPar->fmuonmode, fRunPar->fhoughmuonmode );
 	}

--- a/src/VImageAnalyzerData.cpp
+++ b/src/VImageAnalyzerData.cpp
@@ -6,7 +6,7 @@
 #include <VImageAnalyzerData.h>
 
 VImageAnalyzerData::VImageAnalyzerData( unsigned int iTelID, unsigned int iShortTree,
-                                        bool bCalibration, bool bWriteImagePixelList )
+										bool bCalibration, bool bWriteImagePixelList )
 {
 	fTelID = iTelID;
 	if( !bCalibration )
@@ -20,8 +20,8 @@ VImageAnalyzerData::VImageAnalyzerData( unsigned int iTelID, unsigned int iShort
 	
 	if( !bCalibration )
 	{
-        fImageParameter = new VImageParameter( iShortTree, bWriteImagePixelList );
-        fImageParameterLogL = new VImageParameter( iShortTree, bWriteImagePixelList );
+		fImageParameter = new VImageParameter( iShortTree, bWriteImagePixelList );
+		fImageParameterLogL = new VImageParameter( iShortTree, bWriteImagePixelList );
 	}
 	
 	// initialize time since run start
@@ -289,7 +289,7 @@ valarray<double>& VImageAnalyzerData::getTZeros( bool iCorrected )
 	// this is a serious problem and should never happen
 	cout << "VImageAnalyzerData::getTZeros error: tzero index out of range" << endl;
 	cout << "\t" << fpulsetiming_tzero_index << "\t" << fPulseTimingCorrected.size() << "\t" << fPulseTimingUncorrected.size() << endl;
-    exit( EXIT_FAILURE );
+	exit( EXIT_FAILURE );
 	
 	return fPulseTimingUncorrected[0]; // should never happen
 }

--- a/src/VImageAnalyzerData.cpp
+++ b/src/VImageAnalyzerData.cpp
@@ -5,7 +5,8 @@
 
 #include <VImageAnalyzerData.h>
 
-VImageAnalyzerData::VImageAnalyzerData( unsigned int iTelID, unsigned int iShortTree, bool bCalibration )
+VImageAnalyzerData::VImageAnalyzerData( unsigned int iTelID, unsigned int iShortTree,
+                                        bool bCalibration, bool bWriteImagePixelList )
 {
 	fTelID = iTelID;
 	if( !bCalibration )
@@ -19,8 +20,8 @@ VImageAnalyzerData::VImageAnalyzerData( unsigned int iTelID, unsigned int iShort
 	
 	if( !bCalibration )
 	{
-		fImageParameter = new VImageParameter( iShortTree );
-		fImageParameterLogL = new VImageParameter( iShortTree );
+        fImageParameter = new VImageParameter( iShortTree, bWriteImagePixelList );
+        fImageParameterLogL = new VImageParameter( iShortTree, bWriteImagePixelList );
 	}
 	
 	// initialize time since run start
@@ -84,7 +85,7 @@ void VImageAnalyzerData::initialize( unsigned int iChannels, unsigned int iMaxCh
 	fCurrentSummationWindow_2.resize( iChannels, 0 );
 	fImage.resize( iChannels, false );
 	fBorder.resize( iChannels, false );
-	fTrigger.resize( iChannels, false );          // MS
+	fTrigger.resize( iChannels, false );
 	fBrightNonImage.resize( iChannels, false );
 	fImageBorderNeighbour.resize( iChannels, false );
 	fTraceWidth.resize( iChannels, 0. );
@@ -93,14 +94,14 @@ void VImageAnalyzerData::initialize( unsigned int iChannels, unsigned int iMaxCh
 	fRawTraceMax.resize( iChannels, 0. );
 	fImageUser.resize( iChannels, 0 );
 	
-	fClusterID.resize( iChannels, 0 ); //HP
-	fClusterNpix.resize( iChannels, 0 ); //HP
-	fClusterSize.resize( iChannels, 0. ); //HP
-	fClusterTime.resize( iChannels, 0. ); //HP
-	fClusterCenx.resize( iChannels, 0. ); //HP
-	fClusterCeny.resize( iChannels, 0. ); //HP
-	fncluster_cleaned = 0; //HP
-	fncluster_uncleaned = 0; //HP
+	fClusterID.resize( iChannels, 0 );
+	fClusterNpix.resize( iChannels, 0 );
+	fClusterSize.resize( iChannels, 0. );
+	fClusterTime.resize( iChannels, 0. );
+	fClusterCenx.resize( iChannels, 0. );
+	fClusterCeny.resize( iChannels, 0. );
+	fncluster_cleaned = 0;
+	fncluster_uncleaned = 0;
 	
 	fCorrelationCoefficient.resize( iChannels, false );
 	
@@ -132,14 +133,14 @@ void VImageAnalyzerData::initializeMeanPulseHistograms()
 	char htitle[200];
 	for( unsigned int j = 0; j < fNChannels; j++ )
 	{
-		sprintf( hname, "hPulseHigh_%d_%d", fTelID + 1, j );
-		sprintf( htitle, "mean pulse, high gain (tel %d, channel %d)", fTelID + 1, j );
+		sprintf( hname, "hPulseHigh_%d_%u", fTelID + 1, j );
+		sprintf( htitle, "mean pulse, high gain (tel %d, channel %u)", fTelID + 1, j );
 		hMeanPulseHigh.push_back( new TProfile2D( hname, htitle, 50, 0., 5., 2 * fNSamples, -( double )fNSamples, ( double )fNSamples ) );
 		hMeanPulseHigh.back()->SetXTitle( "log_{10} integrated charge" );
 		hMeanPulseHigh.back()->SetYTitle( "sample (time corrected)" );
 		hMeanPulses->Add( hMeanPulseHigh.back() );
-		sprintf( hname, "hPulseLow_%d_%d", fTelID + 1, j );
-		sprintf( htitle, "mean pulse, low gain (tel %d, channel %d)", fTelID + 1, j );
+		sprintf( hname, "hPulseLow_%d_%u", fTelID + 1, j );
+		sprintf( htitle, "mean pulse, low gain (tel %d, channel %u)", fTelID + 1, j );
 		hMeanPulseLow.push_back( new TProfile2D( hname, htitle, 50, 0., 5., 2 * fNSamples, -( double )fNSamples, ( double )fNSamples ) );
 		hMeanPulseLow.back()->SetXTitle( "log_{10} integrated charge" );
 		hMeanPulseLow.back()->SetYTitle( "sample (time corrected)" );
@@ -157,14 +158,14 @@ void VImageAnalyzerData::initializeIntegratedChargeHistograms()
 	char htitle[200];
 	for( unsigned int j = 0; j < fNChannels; j++ )
 	{
-		sprintf( hname, "hSumHigh_%d_%d", fTelID + 1, j );
-		sprintf( htitle, "integrated charge, high gain (tel %d, channel %d)", fTelID + 1, j );
+		sprintf( hname, "hSumHigh_%d_%u", fTelID + 1, j );
+		sprintf( htitle, "integrated charge, high gain (tel %d, channel %u)", fTelID + 1, j );
 		hPulseSumHigh.push_back( new TH1F( hname, htitle, 200, 0., 6. ) );
 		hPulseSumHigh.back()->SetXTitle( "log_{10} integrated charge" );
 		hPulseSum->Add( hPulseSumHigh.back() );
 		
-		sprintf( hname, "hSumLow_%d_%d", fTelID + 1, j );
-		sprintf( htitle, "integrated charge, low gain (tel %d, channel %d)", fTelID + 1, j );
+		sprintf( hname, "hSumLow_%d_%u", fTelID + 1, j );
+		sprintf( htitle, "integrated charge, low gain (tel %d, channel %u)", fTelID + 1, j );
 		hPulseSumLow.push_back( new TH1F( hname, htitle, 200, 0., 6. ) );
 		hPulseSumLow.back()->SetXTitle( "log_{10} integrated charge" );
 		hPulseSum->Add( hPulseSumLow.back() );
@@ -288,7 +289,7 @@ valarray<double>& VImageAnalyzerData::getTZeros( bool iCorrected )
 	// this is a serious problem and should never happen
 	cout << "VImageAnalyzerData::getTZeros error: tzero index out of range" << endl;
 	cout << "\t" << fpulsetiming_tzero_index << "\t" << fPulseTimingCorrected.size() << "\t" << fPulseTimingUncorrected.size() << endl;
-	exit( -1 );
+    exit( EXIT_FAILURE );
 	
 	return fPulseTimingUncorrected[0]; // should never happen
 }

--- a/src/VImageParameter.cpp
+++ b/src/VImageParameter.cpp
@@ -7,11 +7,14 @@
 
 #include "VImageParameter.h"
 
-VImageParameter::VImageParameter( unsigned int iShortTree )
+VImageParameter::VImageParameter( 
+               unsigned int iShortTree,
+               bool iWriteNImagePixels )
 {
 	fMC = false;
 	tpars = 0;
 	fShortTree = iShortTree;
+    fWriteNImagePixels = iWriteNImagePixels;
 	
 	reset();
 }
@@ -57,11 +60,6 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 		tpars->Branch( "fncluster_cleaned", &fncluster_cleaned, "fncluster_cleaned/I" );
 		tpars->Branch( "fncluster_uncleaned", &fncluster_uncleaned, "fncluster_uncleaned/I" );
 	}
-	
-	// telescope position in shower coordinates
-	//tpars->Branch( "Tel_x_SC", &Tel_x_SC, "Tel_x_SC/D" );
-	//tpars->Branch( "Tel_y_SC", &Tel_y_SC, "Tel_y_SC/D" );
-	//tpars->Branch( "Tel_z_SC", &Tel_z_SC, "Tel_z_SC/D" );
 	
 	// MC parameters
 	if( iMC && fShortTree < 1 )
@@ -122,7 +120,7 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 	tpars->Branch( "sinphi", &sinphi, "sinphi/F" );
 	
 	tpars->Branch( "ntubes", &ntubes, "ntubes/s" );
-	// MS contains number of triggered pixels
+	// contains number of triggered pixels
 	tpars->Branch( "trig_tubes", &trig_tubes, "trig_tubes/s" );
 	tpars->Branch( "nzerosuppressed", &nzerosuppressed, "nzerosuppressed/s" );
 	tpars->Branch( "nsat", &nsat, "nsat/s" );
@@ -178,7 +176,6 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 	}
 	
 	// log likelihood fit errors/results
-	
 	tpars->Branch( "Fitstat", &Fitstat, "Fitstat/I" );
 	if( iLL )
 	{
@@ -206,6 +203,23 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 		tpars->Branch( "signal", &signal, "signal/F" );
 		tpars->Branch( "dsignal", &dsignal, "dsignal/F" );
 	}
+    tpars->Branch( "dcen_x", &dcen_x, "dcen_x/F" );
+    tpars->Branch( "dcen_y", &dcen_y, "dcen_y/F" );
+    tpars->Branch( "dlength", &dlength, "dlength/F" );
+    tpars->Branch( "dwidth", &dwidth, "dwidth/F" );
+    tpars->Branch( "dphi", &dphi, "dphi/F" );
+
+    // image / border pixel list
+    if( fWriteNImagePixels )
+    {
+        // image pixels
+        tpars->Branch( "PixelListN", &PixelListN, "PixelListN/i" );
+        tpars->Branch( "PixelID", PixelID, "PixelID[PixelListN]/i" );
+        tpars->Branch( "PixelType", PixelType, "PixelType[PixelListN]/i" );
+        tpars->Branch( "PixelIntensity", PixelIntensity, "PixelIntensity[PixelListN]/F" );
+        tpars->Branch( "PixelTimingT0", PixelTimingT0, "PixelTimingT0[PixelListN]/F" );
+        tpars->Branch( "PixelPE", PixelPE, "PixelPE[PixelListN]/F" );
+    }
 }
 
 
@@ -358,6 +372,15 @@ void VImageParameter::reset( unsigned int resetLevel )
 	houghContained = 0.;
 	houghMuonValid = 0;
 	
+    if( fWriteNImagePixels )
+    {
+        PixelListN = 0;
+        memset( PixelID, 0, VDST_MAXCHANNELS * sizeof(unsigned int));
+        memset( PixelType, 0, VDST_MAXCHANNELS * sizeof(unsigned int));
+        memset( PixelIntensity, 0, VDST_MAXCHANNELS * sizeof(float));
+        memset( PixelTimingT0, 0, VDST_MAXCHANNELS * sizeof(float));
+        memset( PixelPE, 0, VDST_MAXCHANNELS * sizeof(float));
+    }
 }
 
 

--- a/src/VImageParameter.cpp
+++ b/src/VImageParameter.cpp
@@ -218,7 +218,6 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 		tpars->Branch( "PixelType", PixelType, "PixelType[PixelListN]/i" );
 		tpars->Branch( "PixelIntensity", PixelIntensity, "PixelIntensity[PixelListN]/F" );
 		tpars->Branch( "PixelTimingT0", PixelTimingT0, "PixelTimingT0[PixelListN]/F" );
-		tpars->Branch( "PixelPE", PixelPE, "PixelPE[PixelListN]/F" );
 	}
 }
 
@@ -379,7 +378,6 @@ void VImageParameter::reset( unsigned int resetLevel )
 		memset( PixelType, 0, VDST_MAXCHANNELS * sizeof( unsigned int ) );
 		memset( PixelIntensity, 0, VDST_MAXCHANNELS * sizeof( float ) );
 		memset( PixelTimingT0, 0, VDST_MAXCHANNELS * sizeof( float ) );
-		memset( PixelPE, 0, VDST_MAXCHANNELS * sizeof( float ) );
 	}
 }
 

--- a/src/VImageParameter.cpp
+++ b/src/VImageParameter.cpp
@@ -7,14 +7,14 @@
 
 #include "VImageParameter.h"
 
-VImageParameter::VImageParameter( 
-               unsigned int iShortTree,
-               bool iWriteNImagePixels )
+VImageParameter::VImageParameter(
+	unsigned int iShortTree,
+	bool iWriteNImagePixels )
 {
 	fMC = false;
 	tpars = 0;
 	fShortTree = iShortTree;
-    fWriteNImagePixels = iWriteNImagePixels;
+	fWriteNImagePixels = iWriteNImagePixels;
 	
 	reset();
 }
@@ -203,23 +203,23 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 		tpars->Branch( "signal", &signal, "signal/F" );
 		tpars->Branch( "dsignal", &dsignal, "dsignal/F" );
 	}
-    tpars->Branch( "dcen_x", &dcen_x, "dcen_x/F" );
-    tpars->Branch( "dcen_y", &dcen_y, "dcen_y/F" );
-    tpars->Branch( "dlength", &dlength, "dlength/F" );
-    tpars->Branch( "dwidth", &dwidth, "dwidth/F" );
-    tpars->Branch( "dphi", &dphi, "dphi/F" );
-
-    // image / border pixel list
-    if( fWriteNImagePixels )
-    {
-        // image pixels
-        tpars->Branch( "PixelListN", &PixelListN, "PixelListN/i" );
-        tpars->Branch( "PixelID", PixelID, "PixelID[PixelListN]/i" );
-        tpars->Branch( "PixelType", PixelType, "PixelType[PixelListN]/i" );
-        tpars->Branch( "PixelIntensity", PixelIntensity, "PixelIntensity[PixelListN]/F" );
-        tpars->Branch( "PixelTimingT0", PixelTimingT0, "PixelTimingT0[PixelListN]/F" );
-        tpars->Branch( "PixelPE", PixelPE, "PixelPE[PixelListN]/F" );
-    }
+	tpars->Branch( "dcen_x", &dcen_x, "dcen_x/F" );
+	tpars->Branch( "dcen_y", &dcen_y, "dcen_y/F" );
+	tpars->Branch( "dlength", &dlength, "dlength/F" );
+	tpars->Branch( "dwidth", &dwidth, "dwidth/F" );
+	tpars->Branch( "dphi", &dphi, "dphi/F" );
+	
+	// image / border pixel list
+	if( fWriteNImagePixels )
+	{
+		// image pixels
+		tpars->Branch( "PixelListN", &PixelListN, "PixelListN/i" );
+		tpars->Branch( "PixelID", PixelID, "PixelID[PixelListN]/i" );
+		tpars->Branch( "PixelType", PixelType, "PixelType[PixelListN]/i" );
+		tpars->Branch( "PixelIntensity", PixelIntensity, "PixelIntensity[PixelListN]/F" );
+		tpars->Branch( "PixelTimingT0", PixelTimingT0, "PixelTimingT0[PixelListN]/F" );
+		tpars->Branch( "PixelPE", PixelPE, "PixelPE[PixelListN]/F" );
+	}
 }
 
 
@@ -372,15 +372,15 @@ void VImageParameter::reset( unsigned int resetLevel )
 	houghContained = 0.;
 	houghMuonValid = 0;
 	
-    if( fWriteNImagePixels )
-    {
-        PixelListN = 0;
-        memset( PixelID, 0, VDST_MAXCHANNELS * sizeof(unsigned int));
-        memset( PixelType, 0, VDST_MAXCHANNELS * sizeof(unsigned int));
-        memset( PixelIntensity, 0, VDST_MAXCHANNELS * sizeof(float));
-        memset( PixelTimingT0, 0, VDST_MAXCHANNELS * sizeof(float));
-        memset( PixelPE, 0, VDST_MAXCHANNELS * sizeof(float));
-    }
+	if( fWriteNImagePixels )
+	{
+		PixelListN = 0;
+		memset( PixelID, 0, VDST_MAXCHANNELS * sizeof( unsigned int ) );
+		memset( PixelType, 0, VDST_MAXCHANNELS * sizeof( unsigned int ) );
+		memset( PixelIntensity, 0, VDST_MAXCHANNELS * sizeof( float ) );
+		memset( PixelTimingT0, 0, VDST_MAXCHANNELS * sizeof( float ) );
+		memset( PixelPE, 0, VDST_MAXCHANNELS * sizeof( float ) );
+	}
 }
 
 

--- a/src/VImageParameterCalculation.cpp
+++ b/src/VImageParameterCalculation.cpp
@@ -16,8 +16,8 @@ VImageParameterCalculation::VImageParameterCalculation( unsigned int iShortTree,
 		cout << "VImageParameterCalculation::VImageParameterCalculation()" << endl;
 	}
 	fData = iData;
-	fParGeo = new VImageParameter( iShortTree );
-	fParLL =  new VImageParameter( iShortTree );
+	fParGeo = new VImageParameter( iShortTree, fData->getRunParameter()->fWriteImagePixelList );
+	fParLL =  new VImageParameter( iShortTree, fData->getRunParameter()->fWriteImagePixelList );
 	fboolCalcGeo = false;
 	fboolCalcTiming = false;
 	fDetectorGeometry = 0;
@@ -288,7 +288,7 @@ void VImageParameterCalculation::muonRingFinder()
 	if( !getDetectorGeo() )
 	{
 		cout << "VImageParameterCalculation::muonRingFinder error: detector geometry not defined" << endl;
-		exit( 0 );
+        exit( EXIT_FAILURE );
 	}
 	
 	int counter = 0, safty = 0, noChangeX = 0, noChangeY = 0;
@@ -411,7 +411,7 @@ void VImageParameterCalculation::muonRingFinder()
 		x0[0] = x0[1];
 		
 		///*********************************************
-		// TAKE A STEP IN THE Y-DRIRECTION ?
+        // TAKE A STEP IN THE Y-DIRECTION ?
 		///*********************************************
 		//try a different x0[1], see if sigma of r decreases
 		x0[1] = x0[0];
@@ -529,7 +529,7 @@ void VImageParameterCalculation::sizeInMuonRing()
 	}
 	
 	unsigned int i;
-	double xi, yi, rp, size = 0.0, x0, y0, radius, si;
+	double xi, yi, size = 0.0, x0, y0, radius, si;
 	int totalPixels = 0;
 	int offPixels = 0;
 	double xc = 0.; //Centroid x coordinate
@@ -542,7 +542,7 @@ void VImageParameterCalculation::sizeInMuonRing()
 	{
 		xi = getDetectorGeo()->getX()[i];
 		yi = getDetectorGeo()->getY()[i];
-		rp = sqrt( pow( xi - x0 , 2 ) + pow( yi - y0, 2 ) );
+		double rp = sqrt( pow( xi - x0 , 2 ) + pow( yi - y0, 2 ) );
 		
 		if( rp > radius - 0.15 && rp < radius + 0.15 )
 		{
@@ -762,27 +762,6 @@ void VImageParameterCalculation::houghInitialization()
 }
 
 
-//Placeholder for Hough transform based parametrization algorithm
-void VImageParameterCalculation::houghMuonRingFinder()
-{
-
-
-}
-
-
-//Placeholder for Hough transform based size calculator
-void VImageParameterCalculation::houghSizeInMuonRing()
-{
-
-
-
-
-
-
-
-
-
-}
 
 
 //Hough transform muon identification algorithm.
@@ -860,15 +839,14 @@ void VImageParameterCalculation::houghMuonPixelDistribution()
 
 void VImageParameterCalculation::calcTriggerParameters( vector<bool> fTrigger )
 {
-	// MS: This function does:
 	// Calculate the trigger-level centroids
-	double sumx_trig = 0.;                        // MS
-	double sumy_trig = 0.;                        // MS
-	double sumx2_trig = 0.;                       // MS
-	double sumy2_trig = 0.;                       // MS
+	double sumx_trig = 0.;
+	double sumy_trig = 0.;
+	double sumx2_trig = 0.;
+	double sumy2_trig = 0.;
 	int trig_tubes = 0;
 	
-	// MS: calculated trigger-level parameters
+	// calculate trigger-level parameters
 	// loop over all pixels
 	for( unsigned int j = 0; j < fTrigger.size(); j++ )
 	{
@@ -880,30 +858,25 @@ void VImageParameterCalculation::calcTriggerParameters( vector<bool> fTrigger )
 			double xi = getDetectorGeo()->getX()[j];
 			double yi = getDetectorGeo()->getY()[j];
 			
-			sumx_trig += xi;                      // MS
-			sumy_trig += yi;                      // MS
-			sumx2_trig += xi * xi;                // MS
-			sumy2_trig += yi * yi;                // MS
+			sumx_trig += xi;
+			sumy_trig += yi;
+			sumx2_trig += xi * xi;
+			sumy2_trig += yi * yi;
 		}
 	}
 	fParGeo->trig_tubes = trig_tubes;
 	
-	//  MS: store the trigger-level information
 	if( fParGeo->trig_tubes != 0 )
 	{
-		// MS
 		const double xmean_trig = sumx_trig / trig_tubes;
-		// MS
 		const double ymean_trig = sumy_trig / trig_tubes;
-		// MS
 		const double x2mean_trig = sumx2_trig / trig_tubes;
-		// MS
 		const double y2mean_trig = sumy2_trig / trig_tubes;
 		
-		fParGeo->cen_x_trig = xmean_trig;         // MS
-		fParGeo->cen_y_trig = ymean_trig;         // MS
-		fParGeo->cen_x2_trig = x2mean_trig;       // MS
-		fParGeo->cen_y2_trig = y2mean_trig;       // MS
+		fParGeo->cen_x_trig = xmean_trig;
+		fParGeo->cen_y_trig = ymean_trig;
+		fParGeo->cen_x2_trig = x2mean_trig;
+		fParGeo->cen_y2_trig = y2mean_trig;
 	}
 	
 }
@@ -941,7 +914,7 @@ void VImageParameterCalculation::calcParameters()
 	if( !getDetectorGeo() )
 	{
 		cout << "VImageParameterCalculation::calcParameters error: detector geometry not defined" << endl;
-		exit( 0 );
+        exit( EXIT_FAILURE );
 	}
 	
 	double sumsig = 0;
@@ -962,12 +935,12 @@ void VImageParameterCalculation::calcParameters()
 	double sumLowGain = 0.;
 	
 	// calculate mean ped and pedvar
-	double nPixPed = 0.;
 	fParGeo->fmeanPed_Image = 0.;
 	fParGeo->fmeanPedvar_Image = 0.;
 	
 	if( fData->getRunParameter()->doFADCAnalysis() && fData->getReader()->hasFADCTrace() )
 	{
+        double nPixPed = 0.;
 		for( unsigned int j = 0; j < fData->getImageBorderNeighbour().size(); j++ )
 		{
 			if( fData->getImageBorderNeighbour()[j] )
@@ -1017,19 +990,18 @@ void VImageParameterCalculation::calcParameters()
 			pntubesBrightNoImage++;
 		}
 		
+        // loop over image tubes
 		// select image or border pixel
 		if( fData->getImage()[j] || fData->getBorder()[j] )
 		{
 			pntubes += 1;
 			
-			// loop over image tubes
-			
 			double xi = getDetectorGeo()->getX()[j];
 			double yi = getDetectorGeo()->getY()[j];
 			
-			const double si = ( double )fData->getSums()[j]; // charge (dc)
+			double si = ( double )fData->getSums()[j]; // charge (dc)
 			sumsig += si;
-			const double si2 = ( double )fData->getSums2()[j];
+			double si2 = ( double )fData->getSums2()[j];
 			sumsig_2 += si2;
 			// sum in outer ring
 			if( getDetectorGeo()->getNNeighbours()[j] < getDetectorGeo()->getMaxNeighbour() )
@@ -1153,29 +1125,16 @@ void VImageParameterCalculation::calcParameters()
 	else
 	{
 		double xmean = 0.;
-		if( sumsig > 0. )
-		{
-			xmean = sumxsig / sumsig;
-		}
 		double ymean = 0.;
-		if( sumsig > 0. )
-		{
-			ymean = sumysig / sumsig;
-		}
-		
 		double x2mean = 0.;
-		if( sumsig > 0. )
-		{
-			x2mean = sumx2sig / sumsig;
-		}
 		double y2mean = 0.;
-		if( sumsig > 0. )
-		{
-			y2mean = sumy2sig / sumsig;
-		}
 		double xymean = 0.;
 		if( sumsig > 0. )
 		{
+            xmean = sumxsig / sumsig;
+            ymean = sumysig / sumsig;
+            x2mean = sumx2sig / sumsig;
+            y2mean = sumy2sig / sumsig;
 			xymean = sumxysig / sumsig;
 		}
 		
@@ -1260,18 +1219,12 @@ void VImageParameterCalculation::calcParameters()
 		double length2 = ( sdevx2 + sdevy2 + z ) / 2.0;
 		if( length2 < ZeroTolerence )
 		{
-			//if ( length2 < -(ZeroTolerence) )
-			//	throw Error("Length squared is less than -ZeroTolerence");
-			
 			length2 = 0;
 		}
 		
 		double width2  = ( sdevx2 + sdevy2 - z ) / 2.0;
 		if( width2 < ZeroTolerence )
 		{
-			//if ( width2 < -(ZeroTolerence) )
-			//throw Error("Width squared is less than -ZeroTolerence");
-			
 			width2 = 0;
 		}
 		
@@ -1324,7 +1277,6 @@ void VImageParameterCalculation::calcParameters()
 		////////////////////////////////////////////////////////////////////////////
 		
 		const double sinalpha = ( dist > ZeroTolerence ) ? miss / dist : 0;
-		//  if(sinalpha>1.0)sinalpha=1.0; // Floating point sanity check
 		
 		const double alpha = fabs( TMath::RadToDeg() * asin( sinalpha ) );
 		
@@ -1354,8 +1306,6 @@ void VImageParameterCalculation::calcParameters()
 		////////////////////////////////////////////////////////////////////////////
 		
 		double asymmetry = 0;
-		double minorasymmetry = 0;
-		
 		if( length2 > ZeroTolerence )
 		{
 			const double x3mean = sumx3sig / sumsig;
@@ -1383,23 +1333,6 @@ void VImageParameterCalculation::calcParameters()
 				if( asymmetry3length3 < 0 )
 				{
 					asymmetry = -asymmetry;
-				}
-			}
-			
-			if( width2 > ZeroTolerence )
-			{
-				const double minorasymmetry3width3 =
-					-sdevx3 * sinphi * sinphi2 + 3.0 * sdevx2y * cosphi * sinphi2 -
-					3.0 * sdevxy2 * sinphi * cosphi2 + sdevy3 * cosphi * cosphi2;
-					
-				if( fabs( minorasymmetry3width3 ) > ZeroTolerence )
-				{
-					minorasymmetry = pow( fabs( minorasymmetry3width3 ),
-										  0.333333333333 ) / width;
-					if( minorasymmetry3width3 < 0 )
-					{
-						minorasymmetry = -minorasymmetry;
-					}
 				}
 			}
 		}
@@ -2207,4 +2140,57 @@ void VImageParameterCalculation::setImageBorderPixelPosition( VImageParameter* i
 		}
 		iPar->setImageBorderPixelPosition( i_x, i_y );
 	}
+}
+
+
+/*
+    fill image/border pixel to image parameter tree
+    (optional)
+
+    PixelType == 0: Pe > 0 and not image and not border pixel
+    PixelType == 1: image pixel
+    PixelType == 2: border pixel
+    PixelType == 3: neighbour pixel to image/border
+
+*/
+void VImageParameterCalculation::fillImageBorderPixelTree()
+{
+    if( !fParGeo )
+    {
+        return;
+    }
+    if( !fParGeo->isWriteNImagePixels() )
+    {
+        return;
+    }
+    fParGeo->PixelListN = 0;
+    for( unsigned int i = 0; i < fData->getSums().size(); i++ )
+    {
+        // decide of pixel should be added to list written to tree
+        fParGeo->PixelID[fParGeo->PixelListN] = i;
+        fParGeo->PixelType[fParGeo->PixelListN] = 99;
+        if( fData->getImage()[i] )
+        {
+            fParGeo->PixelType[fParGeo->PixelListN] = 1;
+        }
+        else if( fData->getBorder()[i] )
+        {
+            fParGeo->PixelType[fParGeo->PixelListN] = 2;
+        }
+        else if( fData->getImageBorderNeighbour()[i] )
+        {
+            fParGeo->PixelType[fParGeo->PixelListN] = 3;
+        }
+        if( fParGeo->PixelType[fParGeo->PixelListN] < 99 )
+        {
+            fParGeo->PixelIntensity[fParGeo->PixelListN] = fData->getSums()[i];
+            fParGeo->PixelTimingT0[fParGeo->PixelListN] = fData->getPulseTime()[i];
+            // low-gain channel: add '10' to pixel type
+            if( fData->getHiLo()[i] )
+            {
+                fParGeo->PixelType[fParGeo->PixelListN] += 10;
+            } 
+            fParGeo->PixelListN++;
+        }
+    }
 }

--- a/src/VImageParameterCalculation.cpp
+++ b/src/VImageParameterCalculation.cpp
@@ -288,7 +288,7 @@ void VImageParameterCalculation::muonRingFinder()
 	if( !getDetectorGeo() )
 	{
 		cout << "VImageParameterCalculation::muonRingFinder error: detector geometry not defined" << endl;
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 	
 	int counter = 0, safty = 0, noChangeX = 0, noChangeY = 0;
@@ -411,7 +411,7 @@ void VImageParameterCalculation::muonRingFinder()
 		x0[0] = x0[1];
 		
 		///*********************************************
-        // TAKE A STEP IN THE Y-DIRECTION ?
+		// TAKE A STEP IN THE Y-DIRECTION ?
 		///*********************************************
 		//try a different x0[1], see if sigma of r decreases
 		x0[1] = x0[0];
@@ -914,7 +914,7 @@ void VImageParameterCalculation::calcParameters()
 	if( !getDetectorGeo() )
 	{
 		cout << "VImageParameterCalculation::calcParameters error: detector geometry not defined" << endl;
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 	
 	double sumsig = 0;
@@ -940,7 +940,7 @@ void VImageParameterCalculation::calcParameters()
 	
 	if( fData->getRunParameter()->doFADCAnalysis() && fData->getReader()->hasFADCTrace() )
 	{
-        double nPixPed = 0.;
+		double nPixPed = 0.;
 		for( unsigned int j = 0; j < fData->getImageBorderNeighbour().size(); j++ )
 		{
 			if( fData->getImageBorderNeighbour()[j] )
@@ -990,7 +990,7 @@ void VImageParameterCalculation::calcParameters()
 			pntubesBrightNoImage++;
 		}
 		
-        // loop over image tubes
+		// loop over image tubes
 		// select image or border pixel
 		if( fData->getImage()[j] || fData->getBorder()[j] )
 		{
@@ -1131,10 +1131,10 @@ void VImageParameterCalculation::calcParameters()
 		double xymean = 0.;
 		if( sumsig > 0. )
 		{
-            xmean = sumxsig / sumsig;
-            ymean = sumysig / sumsig;
-            x2mean = sumx2sig / sumsig;
-            y2mean = sumy2sig / sumsig;
+			xmean = sumxsig / sumsig;
+			ymean = sumysig / sumsig;
+			x2mean = sumx2sig / sumsig;
+			y2mean = sumy2sig / sumsig;
 			xymean = sumxysig / sumsig;
 		}
 		
@@ -2155,42 +2155,42 @@ void VImageParameterCalculation::setImageBorderPixelPosition( VImageParameter* i
 */
 void VImageParameterCalculation::fillImageBorderPixelTree()
 {
-    if( !fParGeo )
-    {
-        return;
-    }
-    if( !fParGeo->isWriteNImagePixels() )
-    {
-        return;
-    }
-    fParGeo->PixelListN = 0;
-    for( unsigned int i = 0; i < fData->getSums().size(); i++ )
-    {
-        // decide of pixel should be added to list written to tree
-        fParGeo->PixelID[fParGeo->PixelListN] = i;
-        fParGeo->PixelType[fParGeo->PixelListN] = 99;
-        if( fData->getImage()[i] )
-        {
-            fParGeo->PixelType[fParGeo->PixelListN] = 1;
-        }
-        else if( fData->getBorder()[i] )
-        {
-            fParGeo->PixelType[fParGeo->PixelListN] = 2;
-        }
-        else if( fData->getImageBorderNeighbour()[i] )
-        {
-            fParGeo->PixelType[fParGeo->PixelListN] = 3;
-        }
-        if( fParGeo->PixelType[fParGeo->PixelListN] < 99 )
-        {
-            fParGeo->PixelIntensity[fParGeo->PixelListN] = fData->getSums()[i];
-            fParGeo->PixelTimingT0[fParGeo->PixelListN] = fData->getPulseTime()[i];
-            // low-gain channel: add '10' to pixel type
-            if( fData->getHiLo()[i] )
-            {
-                fParGeo->PixelType[fParGeo->PixelListN] += 10;
-            } 
-            fParGeo->PixelListN++;
-        }
-    }
+	if( !fParGeo )
+	{
+		return;
+	}
+	if( !fParGeo->isWriteNImagePixels() )
+	{
+		return;
+	}
+	fParGeo->PixelListN = 0;
+	for( unsigned int i = 0; i < fData->getSums().size(); i++ )
+	{
+		// decide of pixel should be added to list written to tree
+		fParGeo->PixelID[fParGeo->PixelListN] = i;
+		fParGeo->PixelType[fParGeo->PixelListN] = 99;
+		if( fData->getImage()[i] )
+		{
+			fParGeo->PixelType[fParGeo->PixelListN] = 1;
+		}
+		else if( fData->getBorder()[i] )
+		{
+			fParGeo->PixelType[fParGeo->PixelListN] = 2;
+		}
+		else if( fData->getImageBorderNeighbour()[i] )
+		{
+			fParGeo->PixelType[fParGeo->PixelListN] = 3;
+		}
+		if( fParGeo->PixelType[fParGeo->PixelListN] < 99 )
+		{
+			fParGeo->PixelIntensity[fParGeo->PixelListN] = fData->getSums()[i];
+			fParGeo->PixelTimingT0[fParGeo->PixelListN] = fData->getPulseTime()[i];
+			// low-gain channel: add '10' to pixel type
+			if( fData->getHiLo()[i] )
+			{
+				fParGeo->PixelType[fParGeo->PixelListN] += 10;
+			}
+			fParGeo->PixelListN++;
+		}
+	}
 }

--- a/src/VPointingCorrectionsTreeReader.cpp
+++ b/src/VPointingCorrectionsTreeReader.cpp
@@ -80,6 +80,6 @@ float VPointingCorrectionsTreeReader::getCorrected_phi( float cen_x, float cen_y
 	
 	const double ac = ( d + s ) * ymean + 2.0 * sdevxy * xmean;
 	const double bc = 2.0 * sdevxy * ymean - ( d - s ) * xmean;
-
+	
 	return atan2( ac, bc );
 }

--- a/src/VReadRunParameter.cpp
+++ b/src/VReadRunParameter.cpp
@@ -944,10 +944,10 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 		{
 			fRunPara->fWriteExtraCalibTree = true;
 		}
-        else if( iTemp.rfind( "writeimagepixellist" ) < iTemp.size() )
-        {
-            fRunPara->fWriteImagePixelList = true;
-        }
+		else if( iTemp.rfind( "writeimagepixellist" ) < iTemp.size() )
+		{
+			fRunPara->fWriteImagePixelList = true;
+		}
 		else if( i > 1 )
 		{
 			cout << "unknown command line parameter: " << iTemp << endl;

--- a/src/VReadRunParameter.cpp
+++ b/src/VReadRunParameter.cpp
@@ -944,6 +944,10 @@ bool VReadRunParameter::readCommandline( int argc, char* argv[] )
 		{
 			fRunPara->fWriteExtraCalibTree = true;
 		}
+        else if( iTemp.rfind( "writeimagepixellist" ) < iTemp.size() )
+        {
+            fRunPara->fWriteImagePixelList = true;
+        }
 		else if( i > 1 )
 		{
 			cout << "unknown command line parameter: " << iTemp << endl;

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -358,23 +358,22 @@ bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
 	fShower_Xoffset = xoff;
 	fShower_Yoffset = yoff;
 	
-	// ze / az
-	double ze = 0.;
+	double el = 0.;
 	double az = 0.;
 	VAstronometry::vlaDtp2s( -1.* fShower_Xoffset * TMath::DegToRad(),
 							 fShower_Yoffset * TMath::DegToRad(),
 							 fTelAzimuth * TMath::DegToRad(),
 							 fTelElevation * TMath::DegToRad(),
-							 &az, &ze );
-	az *= TMath::RadToDeg();
-	ze = 90. - ze * TMath::RadToDeg();
-	
-	if( TMath::IsNaN( ze ) )
+							 &az, &el );
+	if( TMath::IsNaN( el ) )
 	{
 		fShower_Ze = -99999.;
 	}
-	fShower_Ze = ze;
-	fShower_Az = VAstronometry::vlaDranrm( az * TMath::DegToRad() ) * TMath::RadToDeg();
+    else
+    {
+        fShower_Ze = 90. - el * TMath::RadToDeg();
+    }
+	fShower_Az = VAstronometry::vlaDranrm( az ) * TMath::RadToDeg();
 	
 	return true;
 }

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -369,10 +369,10 @@ bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
 	{
 		fShower_Ze = -99999.;
 	}
-    else
-    {
-        fShower_Ze = 90. - el * TMath::RadToDeg();
-    }
+	else
+	{
+		fShower_Ze = 90. - el * TMath::RadToDeg();
+	}
 	fShower_Az = VAstronometry::vlaDranrm( az ) * TMath::RadToDeg();
 	
 	return true;


### PR DESCRIPTION
Add option `-writeimagepixellist` to evndisp to write out list of pixel (with integrated charge and timing) surviving the image cleaning.

Written are image, border pixels, and one additional ring of pixels around them.

Written the pars trees:
```

```