### PR TITLE
Add pointing corrections for dispBDTs

### DIFF
--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -104,21 +104,23 @@ class VDispAnalyzer
 									  vector< float > x, vector< float > y,
 									  vector< float > cosphi, vector< float > sinphi,
 									  vector< float > v_disp, vector< float > v_weight,
+									  vector< float > tel_pointing_dx,
+									  vector< float > tel_pointing_dy,
 									  float& dispdiff,
 									  float x_off4 = -999., float yoff_4 = -999. );
 									  
-									  
-		void calculateMeanDirection( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
-									 ULong64_t* iTelType,
-									 double* img_size, double* img_cen_x, double* img_cen_y,
-									 double* img_cosphi, double* img_sinphi,
-									 double* img_width, double* img_length, double* img_asym,
-									 double* img_tgrad, double* img_loss, int* img_ntubes,
-									 double* img_weight,
-									 double xoff_4, double yoff_4,
-									 vector< float > dispErrorT,
-									 float* img_pedvar );
-									 
+		void calculateMeanDispDirection( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
+										 ULong64_t* iTelType,
+										 double* img_size, double* img_cen_x, double* img_cen_y,
+										 double* img_cosphi, double* img_sinphi,
+										 double* img_width, double* img_length, double* img_asym,
+										 double* img_tgrad, double* img_loss, int* img_ntubes,
+										 double* img_weight,
+										 double xoff_4, double yoff_4,
+										 vector< float > dispErrorT,
+										 float* img_pedvar,
+										 double* pointing_dx, double* pointing_dy );
+										 
 		void calculateExpectedDirectionError( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
 											  ULong64_t* iTelType,
 											  double* img_size, double* img_cen_x, double* img_cen_y,

--- a/inc/VPointingCorrectionsTreeReader.h
+++ b/inc/VPointingCorrectionsTreeReader.h
@@ -31,6 +31,15 @@ class VPointingCorrectionsTreeReader
 		float getCorrected_cen_x( float cen_x );
 		float getCorrected_cen_y( float cen_y );
 		float getCorrected_phi( float cen_x, float cen_y, float d, float s, float sdevxy );
+		float getPointErrorX()
+		{
+			return fPointingErrorX;
+		}
+		float getPointErrorY()
+		{
+			return fPointingErrorY;
+		}
+		
 		
 };
 

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -262,6 +262,8 @@ class VTableLookupDataHandler
 		double ftgrad_x  [VDST_MAXTELESCOPES];
 		double ftchisq_x [VDST_MAXTELESCOPES];
 		double fweight   [VDST_MAXTELESCOPES];    //!< always 1.
+		double fpointing_dx[VDST_MAXTELESCOPES];
+		double fpointing_dy[VDST_MAXTELESCOPES];
 		int    fFitstat  [VDST_MAXTELESCOPES];
 		// {-1}
 		double fR        [VDST_MAXTELESCOPES];    //!< distance from each telescope to reconstructed shower core

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -163,6 +163,7 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 		vector< float > x, vector< float > y,
 		vector< float > cosphi, vector< float > sinphi,
 		vector< float > v_disp, vector< float > v_weight,
+		vector< float > tel_pointing_dx, vector< float > tel_pointing_dy,
 		float& dispdiff,
 		float x_off4, float yoff_4 )
 {
@@ -281,11 +282,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			// image #1
 			if( ii == 0 )
 			{
-				x1 = x[ii] - v_disp[ii] * cosphi[ii];
-				x2 = x[ii] + v_disp[ii] * cosphi[ii];
+				x1 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x2 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y1 = y[ii] - v_disp[ii] * sinphi[ii];
-				y2 = y[ii] + v_disp[ii] * sinphi[ii];
+				y1 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y2 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				fdisp_xs_T[0] = x1;
 				fdisp_ys_T[0] = y1;
@@ -295,11 +296,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			// image #2
 			else if( ii == 1 )
 			{
-				x3 = x[ii] - v_disp[ii] * cosphi[ii];
-				x4 = x[ii] + v_disp[ii] * cosphi[ii];
+				x3 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x4 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y3 = y[ii] - v_disp[ii] * sinphi[ii];
-				y4 = y[ii] + v_disp[ii] * sinphi[ii];
+				y3 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y4 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				if( ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) < ( x1 - x4 ) * ( x1 - x4 ) + ( y1 - y4 ) * ( y1 - y4 )
 						&& ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) < ( x2 - x3 ) * ( x2 - x3 ) + ( y2 - y3 ) * ( y2 - y3 )
@@ -348,11 +349,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			// image #3
 			else if( ii == 2 )
 			{
-				x5 = x[ii] - v_disp[ii] * cosphi[ii];
-				x6 = x[ii] + v_disp[ii] * cosphi[ii];
+				x5 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x6 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y5 = y[ii] - v_disp[ii] * sinphi[ii];
-				y6 = y[ii] + v_disp[ii] * sinphi[ii];
+				y5 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y6 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				if( ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x3 ) * ( x2 - x3 ) + ( y2 - y3 ) * ( y2 - y3 ) + ( x2 - x5 ) * ( x2 - x5 ) + ( y2 - y5 ) * ( y2 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x1 - x4 ) * ( x1 - x4 ) + ( y1 - y4 ) * ( y1 - y4 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x4 - x5 ) * ( x4 - x5 ) + ( y4 - y5 ) * ( y4 - y5 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x4 ) * ( x2 - x4 ) + ( y2 - y4 ) * ( y2 - y4 ) + ( x2 - x5 ) * ( x2 - x5 ) + ( y2 - y5 ) * ( y2 - y5 ) + ( x4 - x5 ) * ( x4 - x5 ) + ( y4 - y5 ) * ( y4 - y5 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x6 ) * ( x1 - x6 ) + ( y1 - y6 ) * ( y1 - y6 ) + ( x3 - x6 ) * ( x3 - x6 ) + ( y3 - y6 ) * ( y3 - y6 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x3 ) * ( x2 - x3 ) + ( y2 - y3 ) * ( y2 - y3 ) + ( x2 - x6 ) * ( x2 - x6 ) + ( y2 - y6 ) * ( y2 - y6 ) + ( x3 - x6 ) * ( x3 - x6 ) + ( y3 - y6 ) * ( y3 - y6 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x1 - x4 ) * ( x1 - x4 ) + ( y1 - y4 ) * ( y1 - y4 ) + ( x1 - x6 ) * ( x1 - x6 ) + ( y1 - y6 ) * ( y1 - y6 ) + ( x4 - x6 ) * ( x4 - x6 ) + ( y4 - y6 ) * ( y4 - y6 ) && ( x1 - x3 ) * ( x1 - x3 ) + ( y1 - y3 ) * ( y1 - y3 ) + ( x1 - x5 ) * ( x1 - x5 ) + ( y1 - y5 ) * ( y1 - y5 ) + ( x3 - x5 ) * ( x3 - x5 ) + ( y3 - y5 ) * ( y3 - y5 ) < ( x2 - x4 ) * ( x2 - x4 ) + ( y2 - y4 ) * ( y2 - y4 ) + ( x2 - x6 ) * ( x2 - x6 ) + ( y2 - y6 ) * ( y2 - y6 ) + ( x4 - x6 ) * ( x4 - x6 ) + ( y4 - y6 ) * ( y4 - y6 ) )
 				{
@@ -445,11 +446,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 			if( ii == 3 )
 			{
 			
-				x3 = x[ii] - v_disp[ii] * cosphi[ii];
-				x4 = x[ii] + v_disp[ii] * cosphi[ii];
+				x3 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+				x4 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 				
-				y3 = y[ii] - v_disp[ii] * sinphi[ii];
-				y4 = y[ii] + v_disp[ii] * sinphi[ii];
+				y3 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+				y4 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 				
 				
 				if( ( xs - x3 ) * ( xs - x3 ) + ( ys - y3 ) * ( ys - y3 ) < ( xs - x4 ) * ( xs - x4 ) + ( ys - y4 ) * ( ys - y4 ) )
@@ -487,11 +488,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
 		
 		for( unsigned int ii = 0; ii < v_weight.size(); ii++ )
 		{
-			x1 = x[ii] - v_disp[ii] * cosphi[ii];
-			x2 = x[ii] + v_disp[ii] * cosphi[ii];
+			x1 = x[ii] - v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
+			x2 = x[ii] + v_disp[ii] * cosphi[ii] + tel_pointing_dx[ii];
 			
-			y1 = y[ii] - v_disp[ii] * sinphi[ii];
-			y2 = y[ii] + v_disp[ii] * sinphi[ii];
+			y1 = y[ii] - v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
+			y2 = y[ii] + v_disp[ii] * sinphi[ii] + tel_pointing_dy[ii];
 			
 			// check solution closest to starting value
 			// (should work properly here, as these are
@@ -584,13 +585,13 @@ void VDispAnalyzer::calculateMeanShowerDirection( vector< float > v_x, vector< f
 }
 
 /*
- * calculate mean direction using as input C arrays
+ * calculate mean disp direction using as input C arrays
  * (used primarily from lookup table code)
  *
  * called from VTableLookupDataHandler::doStereoReconstruction()
  *
  */
-void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
+void VDispAnalyzer::calculateMeanDispDirection( unsigned int i_ntel,
 		float iArrayElevation,
 		float iArrayAzimuth,
 		ULong64_t* iTelType,
@@ -609,7 +610,9 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
 		double xoff_4,
 		double yoff_4,
 		vector< float > dispErrorT,
-		float* img_pedvar )
+		float* img_pedvar,
+		double* pointing_dx,
+		double* pointing_dy )
 {
 	// reset values from previous event
 	f_disp = -99.;
@@ -636,6 +639,8 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
 	vector< float > y;
 	vector< float > cosphi;
 	vector< float > sinphi;
+	vector< float > tel_pointing_dx;
+	vector< float > tel_pointing_dy;
 	
 	//////////////////////////////
 	// loop over all telescopes and calculate disp per telescope
@@ -690,11 +695,16 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
 			y.push_back( img_cen_y[i] );
 			cosphi.push_back( img_cosphi[i] );
 			sinphi.push_back( img_sinphi[i] );
+			tel_pointing_dx.push_back( pointing_dx[i] );
+			tel_pointing_dy.push_back( pointing_dy[i] );
 		}
 	}
 	
 	// calculate expected direction
-	calculateMeanDirection( f_xs, f_ys, x, y, cosphi, sinphi, v_disp, v_weight, f_dispDiff, xoff_4, yoff_4 );
+	calculateMeanDirection( f_xs, f_ys,
+							x, y, cosphi, sinphi, v_disp, v_weight,
+							tel_pointing_dx, tel_pointing_dy,
+							f_dispDiff, xoff_4, yoff_4 );
 	fdisp_xy_weight_T = v_weight;
 	fdisp_T = v_disp;
 	fdisplist_T = v_displist;

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -369,10 +369,10 @@ bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
 	{
 		fShower_Ze = -99999.;
 	}
-    else
-    {
-        fShower_Ze = 90. - el * TMath::RadToDeg();
-    }
+	else
+	{
+		fShower_Ze = 90. - el * TMath::RadToDeg();
+	}
 	fShower_Az = VAstronometry::vlaDranrm( az ) * TMath::RadToDeg();
 	
 	return true;

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -518,44 +518,18 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 			flength[i] = ftpars[i]->length;
 			ftgrad_x[i] = ftpars[i]->tgrad_x;
 			
+			fcen_x[i] = ftpars[i]->cen_x;
+			fcen_y[i] = ftpars[i]->cen_y;
+			fcosphi[i] = ftpars[i]->cosphi;
+			fsinphi[i] = ftpars[i]->sinphi;
+			fpointing_dx[i] = 0.;
+			fpointing_dy[i] = 0.;
 			if( i < fpointingCorrections.size() && fpointingCorrections[i]
 					&& fpointingCorrections[i]->is_initialized() )
 			{
 				fpointingCorrections[i]->getEntry( fEventCounter );
-				// fpointing_dx[i] = fpointingCorrections[i]->getPointErrorX();
-				// fpointing_dy[i] = fpointingCorrections[i]->getPointErrorY();
-				fpointing_dx[i] = 0.;
-				fpointing_dy[i] = 0.;
-				
-				// TEMP TODO understand better pointing corrections
-				bool fApplyPointCorrectionToImageParameters = false;
-				if( fApplyPointCorrectionToImageParameters )
-				{
-					fcen_x[i] = fpointingCorrections[i]->getCorrected_cen_x( ftpars[i]->cen_x );
-					fcen_y[i] = fpointingCorrections[i]->getCorrected_cen_y( ftpars[i]->cen_y );
-					fcen_x[i] = fpointingCorrections[i]->getCorrected_cen_x( ftpars[i]->cen_x );
-					fcen_y[i] = fpointingCorrections[i]->getCorrected_cen_y( ftpars[i]->cen_y );
-					if( ftpars[i]->has_sdevxy() )
-					{
-						float phi = fpointingCorrections[i]->getCorrected_phi(
-										ftpars[i]->cen_x,
-										ftpars[i]->cen_y,
-										ftpars[i]->f_d,
-										ftpars[i]->f_s,
-										ftpars[i]->f_sdevxy );
-						fcosphi[i] = cos( phi );
-						fsinphi[i] = sin( phi );
-					}
-				}
-			}
-			else
-			{
-				fcen_x[i] = ftpars[i]->cen_x;
-				fcen_y[i] = ftpars[i]->cen_y;
-				fcosphi[i] = ftpars[i]->cosphi;
-				fsinphi[i] = ftpars[i]->sinphi;
-				fpointing_dx[i] = 0.;
-				fpointing_dy[i] = 0.;
+				fpointing_dx[i] = fpointingCorrections[i]->getPointErrorX();
+				fpointing_dy[i] = fpointingCorrections[i]->getPointErrorY();
 			}
 			
 			if( fsize[i] > SizeSecondMax_temp )

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -522,18 +522,30 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 					&& fpointingCorrections[i]->is_initialized() )
 			{
 				fpointingCorrections[i]->getEntry( fEventCounter );
-				fcen_x[i] = fpointingCorrections[i]->getCorrected_cen_x( ftpars[i]->cen_x );
-				fcen_y[i] = fpointingCorrections[i]->getCorrected_cen_y( ftpars[i]->cen_y );
-				if( ftpars[i]->has_sdevxy() )
+				// fpointing_dx[i] = fpointingCorrections[i]->getPointErrorX();
+				// fpointing_dy[i] = fpointingCorrections[i]->getPointErrorY();
+				fpointing_dx[i] = 0.;
+				fpointing_dy[i] = 0.;
+				
+				// TEMP TODO understand better pointing corrections
+				bool fApplyPointCorrectionToImageParameters = false;
+				if( fApplyPointCorrectionToImageParameters )
 				{
-					float phi = fpointingCorrections[i]->getCorrected_phi(
-									ftpars[i]->cen_x,
-									ftpars[i]->cen_y,
-									ftpars[i]->f_d,
-									ftpars[i]->f_s,
-									ftpars[i]->f_sdevxy );
-					fcosphi[i] = cos( phi );
-					fsinphi[i] = sin( phi );
+					fcen_x[i] = fpointingCorrections[i]->getCorrected_cen_x( ftpars[i]->cen_x );
+					fcen_y[i] = fpointingCorrections[i]->getCorrected_cen_y( ftpars[i]->cen_y );
+					fcen_x[i] = fpointingCorrections[i]->getCorrected_cen_x( ftpars[i]->cen_x );
+					fcen_y[i] = fpointingCorrections[i]->getCorrected_cen_y( ftpars[i]->cen_y );
+					if( ftpars[i]->has_sdevxy() )
+					{
+						float phi = fpointingCorrections[i]->getCorrected_phi(
+										ftpars[i]->cen_x,
+										ftpars[i]->cen_y,
+										ftpars[i]->f_d,
+										ftpars[i]->f_s,
+										ftpars[i]->f_sdevxy );
+						fcosphi[i] = cos( phi );
+						fsinphi[i] = sin( phi );
+					}
 				}
 			}
 			else
@@ -542,6 +554,8 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 				fcen_y[i] = ftpars[i]->cen_y;
 				fcosphi[i] = ftpars[i]->cosphi;
 				fsinphi[i] = ftpars[i]->sinphi;
+				fpointing_dx[i] = 0.;
+				fpointing_dy[i] = 0.;
 			}
 			
 			if( fsize[i] > SizeSecondMax_temp )
@@ -681,7 +695,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 		fDispAnalyzerDirection->setQualityCuts( fSSR_NImages_min, fSSR_AxesAngles_min,
 												fTLRunParameter->fmaxdist,
 												fTLRunParameter->fmaxloss );
-		fDispAnalyzerDirection->calculateMeanDirection(
+		fDispAnalyzerDirection->calculateMeanDispDirection(
 			getNTel(),
 			fArrayPointing_Elevation, fArrayPointing_Azimuth,
 			fTel_type,
@@ -694,7 +708,8 @@ void VTableLookupDataHandler::doStereoReconstruction()
 			getWeight(),
 			i_SR.fShower_Xoffset, i_SR.fShower_Yoffset,
 			iDispError,
-			fmeanPedvar_ImageT );
+			fmeanPedvar_ImageT,
+			fpointing_dx, fpointing_dy );
 		// reconstructed direction by disp method:
 		fXoff = fDispAnalyzerDirection->getXcoordinate_disp();
 		fYoff = fDispAnalyzerDirection->getYcoordinate_disp();
@@ -1685,7 +1700,9 @@ bool VTableLookupDataHandler::terminate( TNamed* iM )
 		// copy TTree 'pointingDataReduced' and 'deadPixelRegistry' from evndisp.<>.root to mscw.<>.root
 		if( finputfile.size() > 1 && !fIsMC )
 		{
-			cout << "Warning, VTableLookupDataHandler->finputfile.size() isn't 1, not sure which input file to copy TTree 'pointingDataReduced' from, copying from file finputfile[0]:" << finputfile[0] << endl;
+			cout << "Warning, VTableLookupDataHandler->finputfile.size() isn't 1,";
+			cout << " not sure which input file to copy TTree 'pointingDataReduced'";
+			cout << " from, copying from file finputfile[0]:" << finputfile[0] << endl;
 		}
 		// not sure why we don't want to do this for MC
 		if( finputfile.size() > 0 && !fIsMC )
@@ -2036,6 +2053,8 @@ void VTableLookupDataHandler::resetImageParameters( unsigned int i )
 	fasym[i] = 0.;
 	fcen_x[i] = 0.;
 	fcen_y[i] = 0.;
+	fpointing_dx[i] = 0.;
+	fpointing_dy[i] = 0.;
 	fcosphi[i] = 0.;
 	fsinphi[i] = 0.;
 	fmax1[i] = 0.;
@@ -2238,6 +2257,8 @@ void VTableLookupDataHandler::resetAll()
 		fasym[i] = 0.;
 		fcen_x[i] = 0.;
 		fcen_y[i] = 0.;
+		fpointing_dx[i] = 0.;
+		fpointing_dy[i] = 0.;
 		fcosphi[i] = 0.;
 		fsinphi[i] = 0.;
 		ftgrad_x[i] = 0.;


### PR DESCRIPTION
Correctly x,y reconstructed for each dispBDT using the pointing correction tree.