### PR TITLE
v490 - alpha.6

### DIFF
--- a/inc/VEffectiveAreaCalculatorMCHistograms.h
+++ b/inc/VEffectiveAreaCalculatorMCHistograms.h
@@ -32,7 +32,6 @@ class VEffectiveAreaCalculatorMCHistograms : public TNamed
 		// spectral weight calculator
 		VSpectralWeight*           fSpectralWeight;                 //! backwards compatibility
 		vector< VSpectralWeight* > fVSpectralWeight;                //!
-		
 		double   fMCEnergyRange_TeV_min;
 		double   fMCEnergyRange_TeV_max;
 		double   fMCSpectralIndex;
@@ -41,8 +40,6 @@ class VEffectiveAreaCalculatorMCHistograms : public TNamed
 		int      fEnergyAxisBins_log10;
 		double   fEnergyAxisMin_log10;
 		double   fEnergyAxisMax_log10;
-		
-		
 		
 		int      checkParameters( const VEffectiveAreaCalculatorMCHistograms* );
 		
@@ -56,14 +53,24 @@ class VEffectiveAreaCalculatorMCHistograms : public TNamed
 		// MC histograms
 		vector< vector< TH1D* > > hVEmc;                     // [spectral index][az]
 		vector< vector< TProfile* > > hVEmcSWeight;          // [spectral index][az]
+		vector< TH1D* > hVEmcUnWeighted;                     // [spectral index]
 		
 		VEffectiveAreaCalculatorMCHistograms();
 		~VEffectiveAreaCalculatorMCHistograms() {}
 		
 		bool      add( const VEffectiveAreaCalculatorMCHistograms* );
 		bool      fill( double i_ze, TTree* i_MCData, bool iBAzimuthBins );
+		double    getEnergyAxisMin_log10()
+		{
+			return fEnergyAxisMin_log10;
+		}
+		double    getEnergyAxisMax_log10()
+		{
+			return fEnergyAxisMax_log10;
+		}
 		TH1D*     getHistogram_Emc( unsigned int iAz, unsigned int iIndex );
 		TProfile* getHistogram_EmcWeight( unsigned int iAz, unsigned int iIndex );
+		TH1D*     getHistogram_EmcUnweighted( unsigned int iAz );
 		void      initializeHistograms();
 		void      initializeHistograms( vector< double > iAzMin, vector< double > iAzMax,
 										vector< double > iSpectralIndex,
@@ -88,7 +95,7 @@ class VEffectiveAreaCalculatorMCHistograms : public TNamed
 		void      setDefaultValues();
 		bool      setMonteCarloEnergyRange( double iMin, double iMax, double iMCIndex = 2. );
 		
-		ClassDef( VEffectiveAreaCalculatorMCHistograms, 10 );
+		ClassDef( VEffectiveAreaCalculatorMCHistograms, 13 );
 };
 
 #endif

--- a/inc/VReadRunParameter.h
+++ b/inc/VReadRunParameter.h
@@ -41,6 +41,9 @@ class VReadRunParameter
 		map< unsigned int, double > f_pointingErrorY;
 		double       fWobbleNorth_overwriteDB;
 		double       fWobbleEast_overwriteDB;
+		double       fTargetDec_overwriteDB;
+		double       fTargetRA_overwriteDB;
+		string       fTargetName_overwriteDB;
 		
 		bool checkSecondArgument( std::string, std::string, bool );
 		void isCompiledWithDB();
@@ -49,6 +52,7 @@ class VReadRunParameter
 		void read_db_runinfo();
 		bool readTraceAmplitudeCorrections( string ifile );
 		void setDirectories();
+		double setParameterOverwrite( string ipar_name, double ipar_db, double ipar_db_overwrite );
 		
 	public:
 		VReadRunParameter();

--- a/src/VEffectiveAreaCalculatorMCHistograms.cpp
+++ b/src/VEffectiveAreaCalculatorMCHistograms.cpp
@@ -1,5 +1,6 @@
-/*! \CLASS veFFECTIVEaREAcALCULATORmchISTOGRAMS
+/*! \class VEffectiveAreaCalculatorMCHistograms
     \brief filling, reading, writing of MC histograms for effective area calculation
+
 
 */
 
@@ -20,7 +21,6 @@ VEffectiveAreaCalculatorMCHistograms::VEffectiveAreaCalculatorMCHistograms()
 	fArrayxyoff_MC_min = -1.e5;
 	fArrayxyoff_MC_max =  1.e5;
 	
-	// This should be aligned with all the IRF histograms.
 	fEnergyAxisBins_log10 = 60;
 	fEnergyAxisMin_log10  = -2.;
 	fEnergyAxisMax_log10  =  4.;
@@ -89,10 +89,25 @@ void VEffectiveAreaCalculatorMCHistograms::print()
 					cout << "\tEntries (MCweights): ";
 					cout << getHistogram_EmcWeight( j, i )->GetEntries();
 				}
+				if( getHistogram_EmcUnweighted( j ) && getHistogram_EmcUnweighted( j )->GetEntries() > 0 )
+				{
+					cout << "\t Entries (Unweighted): ";
+					cout << getHistogram_EmcUnweighted( j )->GetEntries();
+				}
 				cout << endl;
 			}
 		}
 	}
+}
+
+TH1D* VEffectiveAreaCalculatorMCHistograms::getHistogram_EmcUnweighted( unsigned int iAz )
+{
+	if( iAz < hVEmcUnWeighted.size() )
+	{
+		return hVEmcUnWeighted[iAz];
+	}
+	
+	return 0;
 }
 
 
@@ -251,6 +266,8 @@ bool VEffectiveAreaCalculatorMCHistograms::fill( double i_ze, TTree* i_MCData, b
 					hVEmcSWeight[s][i_az]->Fill( eMC, i_weight );
 				}
 			}
+			// fill unweighted histogram
+			hVEmcUnWeighted[i_az]->Fill( eMC );
 		}
 	} // end of loop over all MC entries
 	
@@ -284,23 +301,34 @@ void VEffectiveAreaCalculatorMCHistograms::initializeHistograms( vector< double 
 		iT_TH1D.clear();
 		for( unsigned int j = 0; j < fVMinAz.size(); j++ )
 		{
-			sprintf( hname, "hVVEmc_%d_%d", i, j );
+			sprintf( hname, "hVVEmc_%u_%u", i, j );
 			iT_TH1D.push_back( new TH1D( hname, "", nbins, xmin, xmax ) );
 			iT_TH1D.back()->SetXTitle( "energy_{MC} [TeV]" );
-			iT_TH1D.back()->SetYTitle( "entries" );
+			iT_TH1D.back()->SetYTitle( "entries (weighted)" );
 			iT_TH1D.back()->Sumw2();
 		}
 		hVEmc.push_back( iT_TH1D );
 		
 		for( unsigned int j = 0; j < fVMinAz.size(); j++ )
 		{
-			sprintf( hname, "hVVEmcSWeight_%d_%d", i, j );
+			sprintf( hname, "hVVEmcSWeight_%u_%u", i, j );
 			iT_TProfile.push_back( new TProfile( hname, "", nbins, xmin, xmax, 0., 1.e12 ) );
 			iT_TProfile.back()->SetXTitle( "energy_{MC} [TeV]" );
 			iT_TProfile.back()->SetYTitle( "spectral weight" );
 		}
 		hVEmcSWeight.push_back( iT_TProfile );
+		
 	}
+	// unweighted histogram (for debugging purposes)
+	for( unsigned int j = 0; j < fVMinAz.size(); j++ )
+	{
+		sprintf( hname, "hVVEmc_%u", j );
+		hVEmcUnWeighted.push_back( new TH1D( hname, "", nbins, xmin, xmax ) );
+		hVEmcUnWeighted.back()->SetXTitle( "energy_{MC} [TeV]" );
+		hVEmcUnWeighted.back()->SetYTitle( "entries (not weighted)" );
+		hVEmcUnWeighted.back()->Sumw2();
+	}
+	
 	
 	// set spectral weight vector
 	for( unsigned int s = 0; s < fVSpectralIndex.size(); s++ )
@@ -396,9 +424,22 @@ bool VEffectiveAreaCalculatorMCHistograms::add( const VEffectiveAreaCalculatorMC
 		}
 	}
 	
+	for( unsigned int j = 0; j < hVEmcUnWeighted.size(); j++ )
+	{
+		if( hVEmcUnWeighted[j] && iMChis->hVEmcUnWeighted[j] )
+		{
+			hVEmcUnWeighted[j]->Add( iMChis->hVEmcUnWeighted[j] );
+		}
+	}
+	
 	return true;
 }
 
+/*
+
+     note the interesting error coding...
+
+*/
 int VEffectiveAreaCalculatorMCHistograms::checkParameters( const VEffectiveAreaCalculatorMCHistograms* iMChis )
 {
 	if( fDebug )
@@ -534,6 +575,13 @@ bool VEffectiveAreaCalculatorMCHistograms::matchDataVectors( vector< double > iA
 	vector< TProfile* > iP;
 	
 	// match spectral index
+	if( fDebug )
+	{
+		cout << "VEffectiveAreaCalculatorMCHistograms::matchDataVectors: ";
+		cout << "matching spectral index;";
+		cout << " found: " << fVSpectralIndex.size();
+		cout << " requested: " << iSpectralIndex.size() << endl;
+	}
 	for( unsigned int i = 0; i < fVSpectralIndex.size(); i++ )
 	{
 		for( unsigned int j = 0; j < iSpectralIndex.size(); j++ )
@@ -568,6 +616,7 @@ bool VEffectiveAreaCalculatorMCHistograms::matchDataVectors( vector< double > iA
 	// match azimuth vector
 	vector< double > iVMinAz_new;
 	vector< double > iVMaxAz_new;
+	vector< unsigned int > iVAz_match;
 	for( unsigned int s = 0; s < fVSpectralIndex.size(); s++ )
 	{
 		iVMinAz_new.clear();
@@ -587,6 +636,7 @@ bool VEffectiveAreaCalculatorMCHistograms::matchDataVectors( vector< double > iA
 					iVMaxAz_new.push_back( iAzMax[i] );
 					ihVEmc_new.push_back( hVEmc[s][j] );
 					iVEmcSWeight_new.push_back( hVEmcSWeight[s][j] );
+					iVAz_match.push_back( j );
 				}
 			}
 		}
@@ -595,6 +645,17 @@ bool VEffectiveAreaCalculatorMCHistograms::matchDataVectors( vector< double > iA
 	}
 	fVMinAz = iVMinAz_new;
 	fVMaxAz = iVMaxAz_new;
+	
+	// unweighted histogram
+	vector< TH1D* > ihVEmcUnWeighted_new;
+	for( unsigned int i = 0; i < iVAz_match.size(); i++ )
+	{
+		if( iVAz_match[i] < hVEmcUnWeighted.size() )
+		{
+			ihVEmcUnWeighted_new.push_back( hVEmcUnWeighted[iVAz_match[i]] );
+		}
+	}
+	hVEmcUnWeighted = ihVEmcUnWeighted_new;
 	
 	return true;
 }

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -53,6 +53,8 @@ void VSimpleStereoReconstructor::reset()
       Hofmann et al 1999, Method 1 (HEGRA method)
 
       shower direction by intersection of image axes
+      shower core by intersection of lines connecting reconstruced shower
+      direction and image centroids
 
       corresponds to rcs_method4 in VArrayAnalyzer
 
@@ -391,7 +393,7 @@ bool VSimpleStereoReconstructor::reconstruct_core( unsigned int i_ntel,
 bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
 {
 	if( TMath::IsNaN( yoff ) || TMath::IsNaN( yoff )
-			|| xoff < -99998. || yoff < -99998. || yoff > 99999.5 )
+			|| xoff < -998. || yoff < -998. || yoff > 998. )
 	{
 		reset();
 		return false;
@@ -465,4 +467,3 @@ bool VSimpleStereoReconstructor::fillShowerCore( float ximp, float yimp )
 	}
 	return true;
 }
-

--- a/src/VTableLookup.cpp
+++ b/src/VTableLookup.cpp
@@ -12,7 +12,7 @@ VTableLookup::VTableLookup( char ireadwrite, unsigned int iDebug )
 {
 	fDebug = iDebug;
 	
-    // total number of telescopes
+	// total number of telescopes
 	fNTel = 0;
 	// look up table file
 	fLookupTableFile = 0;
@@ -48,7 +48,7 @@ VTableLookup::VTableLookup( char ireadwrite, unsigned int iDebug )
 	cout << "-------------------------------------------------------" << endl;
 	if( fwrite )
 	{
-        cout << "filling lookup tables" << endl;
+		cout << "filling lookup tables" << endl;
 	}
 	else
 	{
@@ -128,7 +128,7 @@ void VTableLookup::setMCTableFiles( string itablefile, double ize, int woff, int
 	{
 		cout << "VTableLookup::setMCTableFiles error while opening table file: " << itablefile << endl;
 		cout << "exiting..." << endl;
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 	if( fLookupTableFile->TestBit( TFile::kRecovered ) )
 	{
@@ -302,7 +302,7 @@ void VTableLookup::setMCTableFiles( string itablefile, string isuff, string iInt
 		cout << "void VTableLookup::setMCTableFiles( string itablefile, string isuff )" << endl;
 	}
 	
-    // open table file
+	// open table file
 	gErrorIgnoreLevel = 20001;
 	fLookupTableFile = new TFile( itablefile.c_str() );
 	if( fLookupTableFile->IsZombie() )
@@ -349,12 +349,12 @@ void VTableLookup::setMCTableFiles( string itablefile, string isuff, string iInt
 	vector< vector< vector< vector< VTableCalculator* > > > > iiii_energySR;
 	vector< vector< vector< vector< ULong64_t > > > > iiii_telType;
 	
-    // vector with available NSB levels [tel_type][NSB]
+	// vector with available NSB levels [tel_type][NSB]
 	fTableNoiseLevel.clear();
-    // vector with available zenith angles [tel_type][NSB][ze]
+	// vector with available zenith angles [tel_type][NSB][ze]
 	fTableZe.clear();
 	vector< double > i_ze;
-    // vector with available wobble offsets [tel_type][NSB][ze][woff]
+	// vector with available wobble offsets [tel_type][NSB][ze][woff]
 	fTableDirectionOffset.clear();
 	vector< double > i_DirectionOffset;
 	vector< vector< double > > ii_DirectionOffset;
@@ -468,7 +468,7 @@ void VTableLookup::setMCTableFiles( string itablefile, string isuff, string iInt
 		cout << "     ...did not survive test of table file ! There are missing tables in your table file: " << itablefile << endl;
 		cout << "     You need to redo your table, or contact Gernot if this is the standard table supplied " << endl ;
 		sanityCheckLookupTableFile( true ); // this will print which tables are missing
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 	
 	if( fDebug )
@@ -553,7 +553,7 @@ bool VTableLookup::sanityCheckLookupTableFile( bool iPrint )
 		}
 	}
 	
-    // print a summary of the number of tables found
+	// print a summary of the number of tables found
 	if( iPrint == false )
 	{
 		cout << "Found " << fTableNoiseLevel.size() << " noise levels, " << fTableZe[0].size() << " zenith angles, " << fTableDirectionOffset[0][0].size() << " wobble offsets, " << fTableAzBins << " azimuth bins and " << fTelType_tables[0][0][0][0].size() << " telescope types" << endl;
@@ -773,11 +773,11 @@ void VTableLookup::readLookupTable()
 		{
 			//////////////////////////////////////
 			// here we should have good data only
-            // (ze, az, and wobble offset have been
-            //  tested)
+			// (ze, az, and wobble offset have been
+			//  tested)
 			//////////////////////////////////////
-            
-            // get direction angles for this event
+			
+			// get direction angles for this event
 			ze = fData->getZe();
 			woff = fData->getWobbleOffset();
 			i_az = getAzBin( fData->getAz() );
@@ -1297,7 +1297,7 @@ void VTableLookup::readNoiseLevel( bool bWriteToRunPara )
 	{
 		cout << " VTableLookup::readNoiseLevel ERROR: could not find mean pedestal variation for each telescope" << endl;
 		cout << "exiting...." << endl;
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 }
 
@@ -1341,9 +1341,9 @@ void VTableLookup::getIndexBoundary( unsigned int* iup, unsigned int* ilow, vect
     get pointers to a certain set of tables
 
 */
-void VTableLookup::getTables( unsigned int inoise, unsigned int ize, 
-                              unsigned int iwoff, unsigned int iaz, unsigned int tel, 
-                              VTablesToRead* s )
+void VTableLookup::getTables( unsigned int inoise, unsigned int ize,
+							  unsigned int iwoff, unsigned int iaz, unsigned int tel,
+							  VTablesToRead* s )
 {
 	if( !s )
 	{

--- a/src/mscw_energy.cpp
+++ b/src/mscw_energy.cpp
@@ -27,7 +27,7 @@ void printParametersFromFile( string ff )
 	if( iF.IsZombie() )
 	{
 		cout << "couldn't read mscw file: " << ff << endl;
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 	VTableLookupRunParameter* fX = ( VTableLookupRunParameter* )iF.Get( "TLRunParameter" );
 	if( fX )
@@ -40,7 +40,7 @@ void printParametersFromFile( string ff )
 	}
 	iF.Close();
 	
-    exit( EXIT_SUCCESS );
+	exit( EXIT_SUCCESS );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ int main( int argc, char* argv[] )
 		{
 			VGlobalRunParameter fRunPara;
 			cout << fRunPara.getEVNDISP_VERSION() << endl;
-            exit( EXIT_SUCCESS );
+			exit( EXIT_SUCCESS );
 		}
 	}
 	// timing
@@ -77,13 +77,13 @@ int main( int argc, char* argv[] )
 	
 	if( !fTLRunParameter->fillParameters( argc, argv ) )
 	{
-        exit( EXIT_SUCCESS );
+		exit( EXIT_SUCCESS );
 	}
 	
 	if( fTLRunParameter->printpara.size() > 0 )
 	{
 		printParametersFromFile( fTLRunParameter->printpara );
-        exit( EXIT_SUCCESS );
+		exit( EXIT_SUCCESS );
 	}
 	fTLRunParameter->print();
 	
@@ -93,11 +93,11 @@ int main( int argc, char* argv[] )
 	{
 		cout << "error creating lookup tables: no run parameters";
 		cout << "exiting..." << endl;
-        exit( EXIT_FAILURE );
+		exit( EXIT_FAILURE );
 	}
 	
 	cout << endl << "loop over all events ";
-    if( fTLook->getNEntries() != TChain::kBigNumber )
+	if( fTLook->getNEntries() != TChain::kBigNumber )
 	{
 		cout << "(in total " << fTLook->getNEntries() << ")";
 	}
@@ -107,17 +107,17 @@ int main( int argc, char* argv[] )
 		cout << "\t maximum run time [s]: " << fTLook->getMaxTotalTime() << endl;
 	}
 	
-    //////////////////////////
+	//////////////////////////
 	// loop over all events
 	fTLook->loop();
 	
 	cout << "... end of loop" << endl;
 	
-    // stopwatch results
+	// stopwatch results
 	fStopWatch.Stop();
 	fStopWatch.Print();
 	
-    //////////////////////////
+	//////////////////////////
 	// write tables to disk
 	fTLook->terminate();
 }


### PR DESCRIPTION
Changes related to v490-alpha.4

# Unweighted simulated histograms

Add unweighted histograms to effective area output files (mostly for debugging now; later useful for DL2).

# Command line parameters to overwrite target runinfo DB values

Add possibility to overwrite the DB settings for target information (read usually from the runinfo db table): `-overwritedb_rightascension`, `-overwritedb_declination`,  `-overwritedb_target` (this complements the existing command line options for the wobble offset: `overwritedb_wobblenorth` and `overwritedb_wobbleeast`