### PR TITLE
v490 - alpha.0.8

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,6 @@
 
 - ROOT must be installed 
   version >= 6.20
-  To compile root, use '-Dbuiltin_cfitsio=ON -Dbuiltin_gsl=ON'
 
 - SOFA library (http://www.iausofa.org/current_C.html) must be installed. Use the script in the $EVNDISPSYS directory:
 ```
@@ -13,6 +12,12 @@
 Set the following environmental variable:  SOFASYS=$EVNDISPSYS/sofa
 
 ### VERITAS analysis
+
+Requires installation of the VBF library (VERITAS bank format).
+Note that for newer unix system, adapations to C++17 standards are reqired.
+Use e.g.
+- https://github.com/VERITAS-Observatory/VBF/releases/tag/0.3.4-1-c%2B%2B17 for newer systems C++17 support
+- https://github.com/VERITAS-Observatory/VBF/releases/tag/0.3.4-1 for all other systems
 
 (see VERITAS internal wiki for all details)
 

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -134,7 +134,7 @@ class CData
 		Float_t         EmissionHeightChi2;
 		UInt_t          NTelPairs;
 		//[NTelPairs]
-		Float_t         EmissionHeightT[VDST_MAXTELESCOPES * VDST_MAXTELESCOPES];
+		Float_t         EmissionHeightT[VDST_MAXTELESCOPES* VDST_MAXTELESCOPES];
 		Double_t        DispDiff;  // from disp method
 		
 		// List of branches

--- a/inc/VImageCleaning.h
+++ b/inc/VImageCleaning.h
@@ -24,6 +24,11 @@ class VImageCleaning
 		void printDataError( string iFunctionName );
 		void removeSmallClusters( int );
 		
+		// cluster cleaning
+		void addToCluster( unsigned int cID, unsigned int iChan );
+		void removeCluster( unsigned int cID ) ;
+		vector<int> fNpixCluster;
+		vector<double> fSizeCluster;
 		
 		// NN image cleaning
 		bool  kInitNNImageCleaning;
@@ -99,6 +104,8 @@ class VImageCleaning
 		void cleanImageFixedWithTiming( VImageCleaningRunParameter* iImageCleaningParameters );
 		void cleanImagePedvarsWithTiming( VImageCleaningRunParameter* iImageCleaningParameters );
 		
+		// cluster cleaning
+		void cleanImageWithClusters( VImageCleaningRunParameter* iImageCleaningParameters, bool isFixed );
 		
 		// trace correlation cleaning
 		void cleanImageTraceCorrelate( VImageCleaningRunParameter* iImageCleaningParameters );

--- a/inc/VImageCleaning.h
+++ b/inc/VImageCleaning.h
@@ -22,7 +22,7 @@ class VImageCleaning
 		void mergeClusters();
 		void recoverImagePixelNearDeadPixel();
 		void printDataError( string iFunctionName );
-        void removeIslandOfImageBorderPair( bool = false );
+		void removeIslandOfImageBorderPair();
 		void removeSmallClusters( int );
 		
 		// cluster cleaning

--- a/inc/VImageCleaning.h
+++ b/inc/VImageCleaning.h
@@ -22,6 +22,7 @@ class VImageCleaning
 		void mergeClusters();
 		void recoverImagePixelNearDeadPixel();
 		void printDataError( string iFunctionName );
+        void removeIslandOfImageBorderPair( bool = false );
 		void removeSmallClusters( int );
 		
 		// cluster cleaning

--- a/inc/VImageCleaningRunParameter.h
+++ b/inc/VImageCleaningRunParameter.h
@@ -40,6 +40,10 @@ class VImageCleaningRunParameter
 		double fCorrelationCleanCorrelThresh; //  parameter for trace correlation level (0.6-1.0)
 		int    fCorrelationCleanNpixThresh;   //  Maximum Number of pixels to apply correlation cleaning to (eg 10-15)
 		
+        /////////////////////////////////////////////////
+        // cluster cleaning
+        int fnmaxcluster;
+        double fminsizecluster;
 		
 		/////////////////////////////////////////////////
 		// time two-level

--- a/inc/VImageCleaningRunParameter.h
+++ b/inc/VImageCleaningRunParameter.h
@@ -24,6 +24,7 @@ class VImageCleaningRunParameter
 		double fimagethresh;              // parameter for image threshold
 		double fborderthresh;             // parameter for border threshold
 		double fbrightnonimagetresh;      // parameter for bright pixels threshold
+        bool fremoveIslandOfImageBorderPair; // remove single image with single border pixels
 		
 		bool fUseFixedThresholds;         // use fixed image/border thresholds instead of multiples of pedestal variances
 		

--- a/inc/VImageCleaningRunParameter.h
+++ b/inc/VImageCleaningRunParameter.h
@@ -40,10 +40,10 @@ class VImageCleaningRunParameter
 		double fCorrelationCleanCorrelThresh; //  parameter for trace correlation level (0.6-1.0)
 		int    fCorrelationCleanNpixThresh;   //  Maximum Number of pixels to apply correlation cleaning to (eg 10-15)
 		
-        /////////////////////////////////////////////////
-        // cluster cleaning
-        int fnmaxcluster;
-        double fminsizecluster;
+		/////////////////////////////////////////////////
+		// cluster cleaning
+		int fnmaxcluster;
+		double fminsizecluster;
 		
 		/////////////////////////////////////////////////
 		// time two-level

--- a/inc/VImageCleaningRunParameter.h
+++ b/inc/VImageCleaningRunParameter.h
@@ -24,7 +24,7 @@ class VImageCleaningRunParameter
 		double fimagethresh;              // parameter for image threshold
 		double fborderthresh;             // parameter for border threshold
 		double fbrightnonimagetresh;      // parameter for bright pixels threshold
-        bool fremoveIslandOfImageBorderPair; // remove single image with single border pixels
+		bool fremoveIslandOfImageBorderPair; // remove single image with single border pixels
 		
 		bool fUseFixedThresholds;         // use fixed image/border thresholds instead of multiples of pedestal variances
 		

--- a/src/FITSRecord.cpp
+++ b/src/FITSRecord.cpp
@@ -52,7 +52,7 @@ FITSRecord::FITSRecord( std::string fits_filename,
 						std::string template_filename,
 						std::string extension_name, int extension_version )
 	: 	 _fptr( NULL ), _own_fptr( true ), _rowcount( 0 ), _verbose( 0 ),
-		_extension_version( 0 ), _is_writable( true ), _is_finished( true )
+		 _extension_version( 0 ), _is_writable( true ), _is_finished( true )
 {
 
 

--- a/src/VEvndispReconstructionParameter.cpp
+++ b/src/VEvndispReconstructionParameter.cpp
@@ -1018,13 +1018,13 @@ unsigned int VEvndispReconstructionParameter::read_arrayAnalysisCuts( string ifi
 								fRunPara->fImageCleaningParameters[i]->fborderthresh = atof( iTemp3.c_str() );
 							}
 						}
-                        if( iTemp4.size() > 0 )
-                        {
-                            if( i < fRunPara->fImageCleaningParameters.size() )
-                            {
-                                fRunPara->fImageCleaningParameters[i]->fremoveIslandOfImageBorderPair = (bool)(atoi(iTemp4.c_str()));
-                            }
-                        }
+						if( iTemp4.size() > 0 )
+						{
+							if( i < fRunPara->fImageCleaningParameters.size() )
+							{
+								fRunPara->fImageCleaningParameters[i]->fremoveIslandOfImageBorderPair = ( bool )( atoi( iTemp4.c_str() ) );
+							}
+						}
 					}
 				}
 				continue;

--- a/src/VEvndispReconstructionParameter.cpp
+++ b/src/VEvndispReconstructionParameter.cpp
@@ -1082,34 +1082,34 @@ unsigned int VEvndispReconstructionParameter::read_arrayAnalysisCuts( string ifi
 				}
 				continue;
 			}
-            else if( iTemp.find( "CLUSTERCLEANINGPARAMETERS" ) != string::npos && fRunPara )
-            {
-                for( unsigned int i = 0; i < fTel_type_perTelescope.size(); i++ )
-                {
-                    if( t_temp < 0 || getTelescopeType_counter( fTel_type_V[i] ) == t_temp )
-                    {
-                        if( i < fRunPara->fImageCleaningParameters.size() && iTemp2.size() > 0 )
-                        {
-                            fRunPara->fImageCleaningParameters[i]->fnmaxcluster = atof( iTemp2.c_str() );
-                        }
-                        if( iTemp3.size() > 0 )
-                        {
-                            if( i < fRunPara->fImageCleaningParameters.size() )
-                            {
-                                fRunPara->fImageCleaningParameters[i]->fminsizecluster = atof( iTemp3.c_str() );
-                            }
-                        }
-                        if( iTemp4.size() > 0 )
-                        {
-                            if( i < fRunPara->fImageCleaningParameters.size() )
-                            {
-                                fRunPara->fImageCleaningParameters[i]->fminpixelcluster = atoi( iTemp4.c_str() );
-                            }
-                        }
-                    }
-                }
-                continue;
-            }
+			else if( iTemp.find( "CLUSTERCLEANINGPARAMETERS" ) != string::npos && fRunPara )
+			{
+				for( unsigned int i = 0; i < fTel_type_V.size(); i++ )
+				{
+					if( t_temp < 0 || getTelescopeType_counter( fTel_type_V[i] ) == t_temp )
+					{
+						if( i < fRunPara->fImageCleaningParameters.size() && iTemp2.size() > 0 )
+						{
+							fRunPara->fImageCleaningParameters[i]->fnmaxcluster = atof( iTemp2.c_str() );
+						}
+						if( iTemp3.size() > 0 )
+						{
+							if( i < fRunPara->fImageCleaningParameters.size() )
+							{
+								fRunPara->fImageCleaningParameters[i]->fminsizecluster = atof( iTemp3.c_str() );
+							}
+						}
+						if( iTemp4.size() > 0 )
+						{
+							if( i < fRunPara->fImageCleaningParameters.size() )
+							{
+								fRunPara->fImageCleaningParameters[i]->fminpixelcluster = atoi( iTemp4.c_str() );
+							}
+						}
+					}
+				}
+				continue;
+			}
 			else if( iTemp == "TIMECLEANINGPARAMETERS" && fRunPara )
 			{
 				for( unsigned int i = 0; i < fTel_type_V.size(); i++ )

--- a/src/VEvndispReconstructionParameter.cpp
+++ b/src/VEvndispReconstructionParameter.cpp
@@ -1018,6 +1018,13 @@ unsigned int VEvndispReconstructionParameter::read_arrayAnalysisCuts( string ifi
 								fRunPara->fImageCleaningParameters[i]->fborderthresh = atof( iTemp3.c_str() );
 							}
 						}
+                        if( iTemp4.size() > 0 )
+                        {
+                            if( i < fRunPara->fImageCleaningParameters.size() )
+                            {
+                                fRunPara->fImageCleaningParameters[i]->fremoveIslandOfImageBorderPair = (bool)(atoi(iTemp4.c_str()));
+                            }
+                        }
 					}
 				}
 				continue;

--- a/src/VEvndispReconstructionParameter.cpp
+++ b/src/VEvndispReconstructionParameter.cpp
@@ -1082,6 +1082,34 @@ unsigned int VEvndispReconstructionParameter::read_arrayAnalysisCuts( string ifi
 				}
 				continue;
 			}
+            else if( iTemp.find( "CLUSTERCLEANINGPARAMETERS" ) != string::npos && fRunPara )
+            {
+                for( unsigned int i = 0; i < fTel_type_perTelescope.size(); i++ )
+                {
+                    if( t_temp < 0 || getTelescopeType_counter( fTel_type_V[i] ) == t_temp )
+                    {
+                        if( i < fRunPara->fImageCleaningParameters.size() && iTemp2.size() > 0 )
+                        {
+                            fRunPara->fImageCleaningParameters[i]->fnmaxcluster = atof( iTemp2.c_str() );
+                        }
+                        if( iTemp3.size() > 0 )
+                        {
+                            if( i < fRunPara->fImageCleaningParameters.size() )
+                            {
+                                fRunPara->fImageCleaningParameters[i]->fminsizecluster = atof( iTemp3.c_str() );
+                            }
+                        }
+                        if( iTemp4.size() > 0 )
+                        {
+                            if( i < fRunPara->fImageCleaningParameters.size() )
+                            {
+                                fRunPara->fImageCleaningParameters[i]->fminpixelcluster = atoi( iTemp4.c_str() );
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
 			else if( iTemp == "TIMECLEANINGPARAMETERS" && fRunPara )
 			{
 				for( unsigned int i = 0; i < fTel_type_V.size(); i++ )
@@ -1706,4 +1734,3 @@ vector< int > VEvndispReconstructionParameter::getTelescopeType_counter_from_Mir
 	}
 	return x;
 }
-

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -197,7 +197,7 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	ftraceamplitudecorrectionFile = "";
 	ftracefit = -1.;
 	ftracefitfunction = "ev";
-	freconstructionparameterfile = "EVNDISP.reconstruction.runparameter.v48x";
+	freconstructionparameterfile = "EVNDISP.reconstruction.runparameter.v4x";
 	
 	////////////////////////////////////////////////////////////////////////////////
 	// pulse timing (fraction of maximum where times are determined)

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -977,6 +977,11 @@ void VImageAnalyzer::imageCleaning()
 		{
 			fVImageCleaning->cleanNNImageFixed( getImageCleaningParameter() );
 		}
+		//cluster cleaning
+		else if( getImageCleaningParameter()->getImageCleaningMethod() == "CLUSTERCLEANING" )
+		{
+			fVImageCleaning->cleanImageWithClusters( getImageCleaningParameter(), true );
+		}
 		// fixed cleaning levels (classic image/border)
 		else
 		{
@@ -1008,6 +1013,11 @@ void VImageAnalyzer::imageCleaning()
 		else if( getImageCleaningParameter()->getImageCleaningMethod() == "TIMETWOLEVEL" )
 		{
 			fVImageCleaning->cleanImagePedvarsTimeDiff( getImageCleaningParameter() );
+		}
+		//cluster cleaning
+		else if( getImageCleaningParameter()->getImageCleaningMethod() == "CLUSTERCLEANING" )
+		{
+			fVImageCleaning->cleanImageWithClusters( getImageCleaningParameter(), false );
 		}
 		else
 		{

--- a/src/VImageCleaning.cpp
+++ b/src/VImageCleaning.cpp
@@ -2222,209 +2222,208 @@ TGraphErrors* VImageCleaning::GetIPRGraph( unsigned int teltype, float ScanWindo
 void VImageCleaning::cleanImageWithClusters( VImageCleaningRunParameter* iImageCleaningParameters, bool isFixed )
 {
 
-    ///////////////////////////////////////////////
-    // setting of image cleaning run parameters
-    if( !iImageCleaningParameters )
-    {
-        return;
-    }
-    double hithresh = iImageCleaningParameters->fimagethresh;
-    double lothresh = iImageCleaningParameters->fborderthresh;
-    double brightthresh = iImageCleaningParameters->fbrightnonimagetresh;
-    int minNumPixel = iImageCleaningParameters->fminpixelcluster;
-    int maxNumCluster = iImageCleaningParameters->fnmaxcluster;
-    double minSizeCluster = iImageCleaningParameters->fminsizecluster;
-    
-    
-    if( fData->getDebugFlag() )
-    {
-        cout << "VImageCleaning::cleanImageWithClusters " << fData->getTelID() << "\t" << brightthresh << endl;
-    }
-    
-    // STEP 1: Select all pixels with a signal > hithresh
-    fData->setImage( false );
-    fData->setBorder( false );
-    fData->setBrightNonImage( false );
-    fData->setImageBorderNeighbour( false );
-    double i_pedvars_i = 0.;
-    
-    for( unsigned int i = 0; i < fData->getNChannels(); i++ )
-    {
-        if( fData->getDetectorGeo()->getAnaPixel()[i] < 1 || fData->getDead( i, fData->getHiLo()[i] ) )
-        {
-            continue;
-        }
-        i_pedvars_i = fData->getPedvars( fData->getCurrentSumWindow()[i], fData->getHiLo()[i] )[i];
-        
-        if( ( isFixed && fData->getSums()[i] > hithresh ) || ( !isFixed && fData->getSums()[i] > hithresh * i_pedvars_i ) )
-        {
-            fData->setImage( i, true );
-            fData->setBorder( i, false );
-        }
-        if( ( isFixed && fData->getSums()[i] > brightthresh ) || ( !isFixed && fData->getSums()[i] > brightthresh * i_pedvars_i ) )
-        {
-            fData->setBrightNonImage( i, true );
-        }
-    }
-    
-    // STEP 2: Make clusters
-    // - group touching core pixels to clusters
-    
-    //in case there is still something in the memory, reset all channels to cluster id 0
-    for( unsigned int i = 0; i < fData->getNChannels(); i++ )
-    {
-        fData->setClusterID( i, 0 );
-    }
-    
-    unsigned int fNCluster = 0;
-    fSizeCluster.clear();
-    fNpixCluster.clear();
-    
-    //cluster 0 is for non-image pixels & non-analyzed pixels.
-    fSizeCluster.push_back( 0 );
-    fNpixCluster.push_back( 0 );
-    
-    for( unsigned int i = 0; i < fData->getNChannels(); i++ )
-    {
-        if( fData->getImage()[i] && fData->getClusterID()[i] == 0 ) //new cluster
-        {
-            fNCluster++;
-            fSizeCluster.push_back( 0 );
-            fNpixCluster.push_back( 0 );
-            //recursively add channel & its neighbors to the cluster.
-            addToCluster( fNCluster, i );
-        }
-    }
-    
-    //find clusters passing the size cuts
-    vector<int> good_clusters;
-    for( unsigned int i = 1; i <= fNCluster; i++ )
-    {
-        if( fSizeCluster.at( i ) >= minSizeCluster && fNpixCluster.at( i ) >= minNumPixel )
-        {
-            good_clusters.push_back( i );
-        }
-        else
-        {
-            removeCluster( i );
-        }
-    }
-    
-    //sort clusters by size. Bubblesort algorithm from wikipedia.
-    unsigned int n = good_clusters.size();
-    do
-    {
-        int newn = 0;
-        for( unsigned int i = 1; i < n; i++ )
-        {
-            if( fSizeCluster.at( good_clusters.at( i - 1 ) ) < fSizeCluster.at( good_clusters.at( i ) ) )
-            {
-                unsigned int temp = good_clusters.at( i );
-                good_clusters.at( i ) = good_clusters.at( i - 1 );
-                good_clusters.at( i - 1 ) = temp;
-                newn = i;
-            }
-        }
-        n = newn;
-    }
-    while( n > 0 );
-    
-    //only keep the nmax largest clusters
-    if( maxNumCluster > 0 )
-    {
-        for( unsigned int i = maxNumCluster; i < good_clusters.size() ; i++ )
-        {
-            removeCluster( good_clusters.at( i ) );
-            good_clusters.erase( good_clusters.begin() + i );
-            i--;
-        }
-    }
-    
-    //add border pixels
-    for( unsigned int i = 0; i < fData->getNChannels(); i++ )
-    {
-        int i_ID = fData->getClusterID()[i];
-        if( fData->getImage()[i] && fData->getClusterID()[i] > 0 )
-        {
-            for( unsigned int j = 0; j < fData->getDetectorGeo()->getNNeighbours()[i]; j++ )
-            {
-                unsigned int k = fData->getDetectorGeo()->getNeighbours()[i][j];
-                if( fData->getImage()[k] || fData->getBorder()[k] )
-                {
-                    continue;
-                }
-                if( ( isFixed && fData->getSums()[k] > lothresh ) || ( !isFixed && fData->getSums()[k] > lothresh * fData->getPedvars( fData->getCurrentSumWindow()[k], fData->getHiLo()[k] )[k] ) )
-                {
-                    fData->setBorder( k, true );
-                    fData->setClusterID( k, i_ID );
-                }
-            }
-        }
-    }
-    
-    // (preli) set the trigger vector in MC case (preli)
-    // trigger vector are image/border tubes
-    if( fData->getReader() )
-    {
-        if( fData->getReader()->getDataFormatNum() == 1 || fData->getReader()->getDataFormatNum() == 4	|| fData->getReader()->getDataFormatNum() == 6 )
-        {
-            fData->getReader()->setTrigger( fData->getImage(), fData->getBorder() );
-        }
-    }
-    // (end of preli)
-    
-    recoverImagePixelNearDeadPixel();
-    fillImageBorderNeighbours();
-    
-    return;
-    
+	///////////////////////////////////////////////
+	// setting of image cleaning run parameters
+	if( !iImageCleaningParameters )
+	{
+		return;
+	}
+	double hithresh = iImageCleaningParameters->fimagethresh;
+	double lothresh = iImageCleaningParameters->fborderthresh;
+	double brightthresh = iImageCleaningParameters->fbrightnonimagetresh;
+	int minNumPixel = iImageCleaningParameters->fminpixelcluster;
+	int maxNumCluster = iImageCleaningParameters->fnmaxcluster;
+	double minSizeCluster = iImageCleaningParameters->fminsizecluster;
+	
+	
+	if( fData->getDebugFlag() )
+	{
+		cout << "VImageCleaning::cleanImageWithClusters " << fData->getTelID() << "\t" << brightthresh << endl;
+	}
+	
+	// STEP 1: Select all pixels with a signal > hithresh
+	fData->setImage( false );
+	fData->setBorder( false );
+	fData->setBrightNonImage( false );
+	fData->setImageBorderNeighbour( false );
+	double i_pedvars_i = 0.;
+	
+	for( unsigned int i = 0; i < fData->getNChannels(); i++ )
+	{
+		if( fData->getDetectorGeo()->getAnaPixel()[i] < 1 || fData->getDead( i, fData->getHiLo()[i] ) )
+		{
+			continue;
+		}
+		i_pedvars_i = fData->getPedvars( fData->getCurrentSumWindow()[i], fData->getHiLo()[i] )[i];
+		
+		if( ( isFixed && fData->getSums()[i] > hithresh ) || ( !isFixed && fData->getSums()[i] > hithresh * i_pedvars_i ) )
+		{
+			fData->setImage( i, true );
+			fData->setBorder( i, false );
+		}
+		if( ( isFixed && fData->getSums()[i] > brightthresh ) || ( !isFixed && fData->getSums()[i] > brightthresh * i_pedvars_i ) )
+		{
+			fData->setBrightNonImage( i, true );
+		}
+	}
+	
+	// STEP 2: Make clusters
+	// - group touching core pixels to clusters
+	
+	//in case there is still something in the memory, reset all channels to cluster id 0
+	for( unsigned int i = 0; i < fData->getNChannels(); i++ )
+	{
+		fData->setClusterID( i, 0 );
+	}
+	
+	unsigned int fNCluster = 0;
+	fSizeCluster.clear();
+	fNpixCluster.clear();
+	
+	//cluster 0 is for non-image pixels & non-analyzed pixels.
+	fSizeCluster.push_back( 0 );
+	fNpixCluster.push_back( 0 );
+	
+	for( unsigned int i = 0; i < fData->getNChannels(); i++ )
+	{
+		if( fData->getImage()[i] && fData->getClusterID()[i] == 0 ) //new cluster
+		{
+			fNCluster++;
+			fSizeCluster.push_back( 0 );
+			fNpixCluster.push_back( 0 );
+			//recursively add channel & its neighbors to the cluster.
+			addToCluster( fNCluster, i );
+		}
+	}
+	
+	//find clusters passing the size cuts
+	vector<int> good_clusters;
+	for( unsigned int i = 1; i <= fNCluster; i++ )
+	{
+		if( fSizeCluster.at( i ) >= minSizeCluster && fNpixCluster.at( i ) >= minNumPixel )
+		{
+			good_clusters.push_back( i );
+		}
+		else
+		{
+			removeCluster( i );
+		}
+	}
+	
+	//sort clusters by size. Bubblesort algorithm from wikipedia.
+	unsigned int n = good_clusters.size();
+	do
+	{
+		int newn = 0;
+		for( unsigned int i = 1; i < n; i++ )
+		{
+			if( fSizeCluster.at( good_clusters.at( i - 1 ) ) < fSizeCluster.at( good_clusters.at( i ) ) )
+			{
+				unsigned int temp = good_clusters.at( i );
+				good_clusters.at( i ) = good_clusters.at( i - 1 );
+				good_clusters.at( i - 1 ) = temp;
+				newn = i;
+			}
+		}
+		n = newn;
+	}
+	while( n > 0 );
+	
+	//only keep the nmax largest clusters
+	if( maxNumCluster > 0 )
+	{
+		for( unsigned int i = maxNumCluster; i < good_clusters.size() ; i++ )
+		{
+			removeCluster( good_clusters.at( i ) );
+			good_clusters.erase( good_clusters.begin() + i );
+			i--;
+		}
+	}
+	
+	//add border pixels
+	for( unsigned int i = 0; i < fData->getNChannels(); i++ )
+	{
+		int i_ID = fData->getClusterID()[i];
+		if( fData->getImage()[i] && fData->getClusterID()[i] > 0 )
+		{
+			for( unsigned int j = 0; j < fData->getDetectorGeo()->getNNeighbours()[i]; j++ )
+			{
+				unsigned int k = fData->getDetectorGeo()->getNeighbours()[i][j];
+				if( fData->getImage()[k] || fData->getBorder()[k] )
+				{
+					continue;
+				}
+				if( ( isFixed && fData->getSums()[k] > lothresh ) || ( !isFixed && fData->getSums()[k] > lothresh * fData->getPedvars( fData->getCurrentSumWindow()[k], fData->getHiLo()[k] )[k] ) )
+				{
+					fData->setBorder( k, true );
+					fData->setClusterID( k, i_ID );
+				}
+			}
+		}
+	}
+	
+	// (preli) set the trigger vector in MC case (preli)
+	// trigger vector are image/border tubes
+	if( fData->getReader() )
+	{
+		if( fData->getReader()->getDataFormatNum() == 1 || fData->getReader()->getDataFormatNum() == 4	|| fData->getReader()->getDataFormatNum() == 6 )
+		{
+			fData->getReader()->setTrigger( fData->getImage(), fData->getBorder() );
+		}
+	}
+	// (end of preli)
+	
+	recoverImagePixelNearDeadPixel();
+	fillImageBorderNeighbours();
+	
+	return;
+	
 }
 
 //recursively add a pixel and its neigboring image pixels to a cluster.
 void VImageCleaning::addToCluster( unsigned int cID, unsigned int iChan )
 {
-    fData->setClusterID( iChan, cID );
-    if( fSizeCluster.size() > ( unsigned int ) cID )
-    {
-        fSizeCluster.at( cID ) += fData->getSums()[iChan];
-    }
-    else
-    {
-        cout << "VImageCleaning::addToCluster warning: ClusterID " << cID << " not available in fSizeCluster vector (size " <<  fSizeCluster.size() << ")" << endl;
-    }
-    if( fNpixCluster.size() > ( unsigned int ) cID )
-    {
-        fNpixCluster.at( cID )++;
-    }
-    else
-    {
-        cout << "VImageCleaning::addToCluster warning: ClusterID " << cID << " not available in fNpixCluster vector (size " <<  fNpixCluster.size() << ")" << endl;
-    }
-    
-    for( unsigned int j = 0; j < fData->getDetectorGeo()->getNNeighbours()[iChan]; j++ )
-    {
-        unsigned int k = fData->getDetectorGeo()->getNeighbours()[iChan][j];
-        if( fData->getImage()[k] && fData->getClusterID()[k] == 0 )
-        {
-            addToCluster( cID, k ) ;
-        }
-    }
-    return;
+	fData->setClusterID( iChan, cID );
+	if( fSizeCluster.size() > ( unsigned int ) cID )
+	{
+		fSizeCluster.at( cID ) += fData->getSums()[iChan];
+	}
+	else
+	{
+		cout << "VImageCleaning::addToCluster warning: ClusterID " << cID << " not available in fSizeCluster vector (size " <<  fSizeCluster.size() << ")" << endl;
+	}
+	if( fNpixCluster.size() > ( unsigned int ) cID )
+	{
+		fNpixCluster.at( cID )++;
+	}
+	else
+	{
+		cout << "VImageCleaning::addToCluster warning: ClusterID " << cID << " not available in fNpixCluster vector (size " <<  fNpixCluster.size() << ")" << endl;
+	}
+	
+	for( unsigned int j = 0; j < fData->getDetectorGeo()->getNNeighbours()[iChan]; j++ )
+	{
+		unsigned int k = fData->getDetectorGeo()->getNeighbours()[iChan][j];
+		if( fData->getImage()[k] && fData->getClusterID()[k] == 0 )
+		{
+			addToCluster( cID, k ) ;
+		}
+	}
+	return;
 }
 
 //remove a cluster (ie. set all its pixels to non-image status)
 void VImageCleaning::removeCluster( unsigned int cID )
 {
-    for( unsigned int i = 0; i < fData->getNChannels(); i++ )
-    {
-        if( fData->getClusterID()[i] == cID )
-        {
-            fData->setImage( i, false );
-        }
-    }
-    return;
+	for( unsigned int i = 0; i < fData->getNChannels(); i++ )
+	{
+		if( fData->getClusterID()[i] == ( int )cID )
+		{
+			fData->setImage( i, false );
+		}
+	}
+	return;
 }
-
 
 
 /*!
@@ -2443,66 +2442,6 @@ void VImageCleaning::removeCluster( unsigned int cID )
    \par minNumPixel minimum number of pixels in a cluster
    \par loop_max number of loops
 */
-
-void VImageCleaning::cleanImageFixedWithTiming( VImageCleaningRunParameter* iImageCleaningParameters )
-{
-    cleanImageWithTiming( iImageCleaningParameters, true );
-}
-
-void VImageCleaning::cleanImagePedvarsWithTiming( VImageCleaningRunParameter* iImageCleaningParameters )
-{
-    cleanImageWithTiming( iImageCleaningParameters, false );
-}
-
-
-void VImageCleaning::cleanImageWithTiming( VImageCleaningRunParameter* iImageCleaningParameters, bool isFixed )
-{
-    ///////////////////////////////////////////////
-    // setting of image cleaning run parameters
-    if( !iImageCleaningParameters )
-    {
-        return;
-    }
-    double hithresh     = iImageCleaningParameters->fimagethresh;
-    double lothresh     = iImageCleaningParameters->fborderthresh;
-    double brightthresh = iImageCleaningParameters->fbrightnonimagetresh;
-    double timeCutPixel = iImageCleaningParameters->ftimecutpixel;
-    double timeCutCluster = iImageCleaningParameters->ftimecutcluster;
-    int minNumPixel     = iImageCleaningParameters->fminpixelcluster;
-    int loop_max        = iImageCleaningParameters->floops;
-    
-    if( fData->getDebugFlag() )
-    {
-        cout << "VImageCleaning::cleanImageWithTiming " << fData->getTelID() << "\t" << brightthresh << endl;
-    }
-    
-    ///////////////////////////////////////////////
-    // check if time gradient was already calculated
-    if( fData->getImageParameters()->tgrad_x == 0 && fData->getImageParameters()->tint_x == 0 )
-    {
-        timeCutPixel = 5.0;
-        timeCutCluster = fData->getNSamples();         // = number of readout samples
-    }
-    else
-
-
-/*!
-  Image cleaning routine using pixel timing information
-  based on Nepomuk's PhD thesis time-cluster cleaning algorithm
-   - uses fixed time differences for discrimination of pixels/clusters
-   - adjusts time difference according to the time gradient
-   - handles single core pixel
-   - BrightNonImages not completely implemented yet (needs checks - but who is really using them?)
-
-   \par hithresh image threshold
-   \par lothresh border threshold
-   \par brightthresh bright pixel threshold
-   \par timeCutPixel time difference between pixels
-   \par timeCutCluster time difference between clusters
-   \par minNumPixel minimum number of pixels in a cluster
-   \par loop_max number of loops
-*/
-
 void VImageCleaning::cleanImageFixedWithTiming( VImageCleaningRunParameter* iImageCleaningParameters )
 {
 	cleanImageWithTiming( iImageCleaningParameters, true );

--- a/src/VImageCleaningRunParameter.cpp
+++ b/src/VImageCleaningRunParameter.cpp
@@ -25,10 +25,10 @@ VImageCleaningRunParameter::VImageCleaningRunParameter( string iName )
 	fminpixelcluster = 3;
 	floops = 2;
 	
-    //cluster cleaning
-    fnmaxcluster = 1;
-    fminsizecluster = 0;
-    
+	//cluster cleaning
+	fnmaxcluster = 1;
+	fminsizecluster = 0;
+	
 	// Trace Correlation Cleaning
 	fCorrelationCleanBoardThresh = 1.0; // S/N ratio of 1
 	fCorrelationCleanCorrelThresh = 0.75; // Sample correlation coefficient of 0.75
@@ -122,23 +122,23 @@ void VImageCleaningRunParameter::print()
 	{
 		cout << "\t\t time constraint between next neighbor pixels (samples): " << ftimediff << endl;
 	}
-    if( getImageCleaningMethodIndex() == 5 )
-    {
-        cout << "\t\t cluster cleaning; " ;
-        if( fnmaxcluster > 0 )
-        {
-            cout << "keep at most " << fnmaxcluster << " clusters; " ;
-        }
-        if( fminsizecluster > 0 )
-        {
-            cout << " min cluster size: " << fminsizecluster;
-        }
-        if( fminpixelcluster > 0 )
-        {
-            cout << " min no. pixels: " << fminpixelcluster;
-        }
-        cout << endl;
-    }
+	if( getImageCleaningMethodIndex() == 5 )
+	{
+		cout << "\t\t cluster cleaning; " ;
+		if( fnmaxcluster > 0 )
+		{
+			cout << "keep at most " << fnmaxcluster << " clusters; " ;
+		}
+		if( fminsizecluster > 0 )
+		{
+			cout << " min cluster size: " << fminsizecluster;
+		}
+		if( fminpixelcluster > 0 )
+		{
+			cout << " min no. pixels: " << fminpixelcluster;
+		}
+		cout << endl;
+	}
 }
 
 
@@ -160,10 +160,10 @@ string VImageCleaningRunParameter::getImageCleaningMethod()
 	{
 		return "TIMETWOLEVEL";
 	}
-    else if( fImageCleaningMethod == 5 )
-    {
-        return "CLUSTERCLEANING";
-    }
+	else if( fImageCleaningMethod == 5 )
+	{
+		return "CLUSTERCLEANING";
+	}
 	return "TWOLEVELCLEANING";
 }
 
@@ -189,10 +189,10 @@ bool VImageCleaningRunParameter::setImageCleaningMethod( string iMethod )
 	{
 		fImageCleaningMethod = 4;
 	}
-    else if( iMethod == "CLUSTERCLEANING" )
-    {
-        fImageCleaningMethod = 5;
-    }
+	else if( iMethod == "CLUSTERCLEANING" )
+	{
+		fImageCleaningMethod = 5;
+	}
 	else
 	{
 		return false;

--- a/src/VImageCleaningRunParameter.cpp
+++ b/src/VImageCleaningRunParameter.cpp
@@ -25,6 +25,10 @@ VImageCleaningRunParameter::VImageCleaningRunParameter( string iName )
 	fminpixelcluster = 3;
 	floops = 2;
 	
+    //cluster cleaning
+    fnmaxcluster = 1;
+    fminsizecluster = 0;
+    
 	// Trace Correlation Cleaning
 	fCorrelationCleanBoardThresh = 1.0; // S/N ratio of 1
 	fCorrelationCleanCorrelThresh = 0.75; // Sample correlation coefficient of 0.75
@@ -118,6 +122,23 @@ void VImageCleaningRunParameter::print()
 	{
 		cout << "\t\t time constraint between next neighbor pixels (samples): " << ftimediff << endl;
 	}
+    if( getImageCleaningMethodIndex() == 5 )
+    {
+        cout << "\t\t cluster cleaning; " ;
+        if( fnmaxcluster > 0 )
+        {
+            cout << "keep at most " << fnmaxcluster << " clusters; " ;
+        }
+        if( fminsizecluster > 0 )
+        {
+            cout << " min cluster size: " << fminsizecluster;
+        }
+        if( fminpixelcluster > 0 )
+        {
+            cout << " min no. pixels: " << fminpixelcluster;
+        }
+        cout << endl;
+    }
 }
 
 
@@ -139,7 +160,10 @@ string VImageCleaningRunParameter::getImageCleaningMethod()
 	{
 		return "TIMETWOLEVEL";
 	}
-	
+    else if( fImageCleaningMethod == 5 )
+    {
+        return "CLUSTERCLEANING";
+    }
 	return "TWOLEVELCLEANING";
 }
 
@@ -165,6 +189,10 @@ bool VImageCleaningRunParameter::setImageCleaningMethod( string iMethod )
 	{
 		fImageCleaningMethod = 4;
 	}
+    else if( iMethod == "CLUSTERCLEANING" )
+    {
+        fImageCleaningMethod = 5;
+    }
 	else
 	{
 		return false;

--- a/src/VImageCleaningRunParameter.cpp
+++ b/src/VImageCleaningRunParameter.cpp
@@ -18,7 +18,7 @@ VImageCleaningRunParameter::VImageCleaningRunParameter( string iName )
 	fimagethresh = 5.0;
 	fborderthresh = 2.5;
 	fbrightnonimagetresh = 2.5;
-    fremoveIslandOfImageBorderPair = false;
+	fremoveIslandOfImageBorderPair = false;
 	
 	// time cluster cleaning
 	ftimecutpixel = 0.5;
@@ -107,10 +107,10 @@ void VImageCleaningRunParameter::print()
 	else if( getImageCleaningMethod() != "TIMENEXTNEIGHBOUR" )
 	{
 		cout << "\t\t (signal-to-noise cleaning thresholds)" << endl;
-        if( fremoveIslandOfImageBorderPair )
-        {
-            cout << "\t\t remove islands of one image plus one border pixel" << endl;
-        }
+		if( fremoveIslandOfImageBorderPair )
+		{
+			cout << "\t\t remove islands of one image plus one border pixel" << endl;
+		}
 	}
 	if( getImageCleaningMethodIndex() == 1 )
 	{

--- a/src/VImageCleaningRunParameter.cpp
+++ b/src/VImageCleaningRunParameter.cpp
@@ -18,6 +18,7 @@ VImageCleaningRunParameter::VImageCleaningRunParameter( string iName )
 	fimagethresh = 5.0;
 	fborderthresh = 2.5;
 	fbrightnonimagetresh = 2.5;
+    fremoveIslandOfImageBorderPair = false;
 	
 	// time cluster cleaning
 	ftimecutpixel = 0.5;
@@ -106,6 +107,10 @@ void VImageCleaningRunParameter::print()
 	else if( getImageCleaningMethod() != "TIMENEXTNEIGHBOUR" )
 	{
 		cout << "\t\t (signal-to-noise cleaning thresholds)" << endl;
+        if( fremoveIslandOfImageBorderPair )
+        {
+            cout << "\t\t remove islands of one image plus one border pixel" << endl;
+        }
 	}
 	if( getImageCleaningMethodIndex() == 1 )
 	{

--- a/src/VRadialAcceptance.cpp
+++ b/src/VRadialAcceptance.cpp
@@ -44,7 +44,7 @@ VRadialAcceptance::VRadialAcceptance( string ifile )
 	if( fAccFile->IsZombie() )
 	{
 		cout << "VRadialAcceptance::VRadialAcceptance error reading acceptance file " << ifile << endl;
-		exit( -1 );
+		exit( EXIT_FAILURE );
 	}
 	
 	char hname[200];

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -309,6 +309,8 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 	}
 	fNImages = fshowerpars->NImages[fMethod];
 	fchi2 = fshowerpars->Chi2[fMethod];
+	fXoff = fshowerpars->Xoff[fMethod];
+	fYoff = fshowerpars->Yoff[fMethod];
 	// for table filling: check as soon as possible if the event is useful
 	if( fwrite && !isReconstructed() )
 	{

--- a/src/combineLookupTables.cpp
+++ b/src/combineLookupTables.cpp
@@ -112,7 +112,7 @@ int main( int argc, char* argv[] )
 		cout << "combineLookupTables <file with list of tables> <output file name> [histogram types to copy] [noise tolerance]" << endl;
 		cout << endl;
 		cout << "[histogram types]:    all, mpv, median (default)" << endl;
-        cout << "[noise tolerance]:    tolerance for combining NSB bins (default==20)" << endl;
+		cout << "[noise tolerance]:    tolerance for combining NSB bins (default==20)" << endl;
 		cout << endl;
 		exit( EXIT_FAILURE );
 	}
@@ -123,12 +123,12 @@ int main( int argc, char* argv[] )
 	{
 		histogram_types = argv[3];
 	}
-    float noise_tolerance = 20.;
-    if( argc == 5 )
-    {
-        noise_tolerance = atof(argv[4]);
-    }
-
+	float noise_tolerance = 20.;
+	if( argc == 5 )
+	{
+		noise_tolerance = atof( argv[4] );
+	}
+	
 	vector< string > hist_to_copy;
 	if( histogram_types == "all" )
 	{
@@ -227,7 +227,7 @@ int main( int argc, char* argv[] )
 void copyDirectory( TDirectory* source,
 					const char* hx,
 					vector< string > hist_to_copy,
-                    float noise_tolerance )
+					float noise_tolerance )
 {
 	//copy all objects and subdirs of directory source as a subdir of the current directory
 	TDirectory* savdir = gDirectory;


### PR DESCRIPTION
Changes related to v490-alpha.7

- improved installation hints
- critical bug fix in filling lookup tables, using the correct direction values

## Combine lookup tables

More flexibility to find correct NSB bins when combing lookup tables; add command line parameters `noise tolerance` in `combineEffectiveAreas`.

## Propagation of cluster cleaning from v5

Propagated cluster cleaning from v5 to v490.

- removes islands with N pixels or with size smaller than a certain value
- settings see `EVNDISP.reconstruction.runparameter.CC.v4x`

## Addition of AP cleaning

Addition of removal of islands consisting of a single image and a single border pixel, triggered by Jamie's study on increased afterpulsing contributions.

- switch this on by adding one parameter `1` to `* -1 IMAGECLEANINGTHRESHOLDS 5. 2.5 1`
- settings see `EVNDISP.reconstruction.runparameter.AP.v4x`

## Improvement of optimized next-neighbour cleaning

Improved handling of short runs when there are not enough entries in the pedestal histograms to determine correct cleaning cuts. In this case, a single average histogram is filled to calculate the cleaning thresholds.
