### PR TITLE
v490 - alpha.13 - bug fixes in time dependent pedvar69 calculation and dead time calculation

### DIFF
--- a/inc/VPlotAnasumHistograms.h
+++ b/inc/VPlotAnasumHistograms.h
@@ -100,7 +100,8 @@ class VPlotAnasumHistograms : public VAnalysisUtilities, public VPlotUtilities, 
 		void            plot_deadTimes();
 		void            plot_mscPlots( int irebin = 2, double xmin = -2., double xmax = 4., string mscwfile = "" );
 		void            plot_qualityHistograms( double iSourceStrength = 1., bool bUpper = true, int iMethod = 0 );
-		TCanvas*        plot_theta2( double t2min = 0., double t2max = 0.3, int irbin = 5 );
+		TCanvas*        plot_theta2( double t2min = 0., double t2max = 0.3, int irbin = 5,
+									 double setYMax = -9999., double setYMin = -9999. );
 		void            plot_theta2Correction();
 		void            plot_UncorrelatedSkyPlots();
 		void            plot_CorrelatedSkyPlots();
@@ -143,7 +144,7 @@ class VPlotAnasumHistograms : public VAnalysisUtilities, public VPlotUtilities, 
 		}
 		bool            setRunNumber( int iRun );                                      // select run for plotting
 		
-		ClassDef( VPlotAnasumHistograms, 15 );
+		ClassDef( VPlotAnasumHistograms, 16 );
 };
 
 #endif

--- a/src/VPedestalCalculator.cpp
+++ b/src/VPedestalCalculator.cpp
@@ -76,9 +76,9 @@ bool VPedestalCalculator::initialize( bool ibCalibrationRun, unsigned int iNPixe
 	reset();
 	
 	// pedestal histogram binning
-	int i_hist_nbin = 1500.;
+	int i_hist_nbin = 2000.;
 	float i_hist_xmin = 0.;
-	float i_hist_xmax = 750.;
+	float i_hist_xmax = 2000.;
 	
 	// set up the trees
 	TDirectory* iDir = gDirectory;
@@ -164,7 +164,7 @@ bool VPedestalCalculator::initialize( bool ibCalibrationRun, unsigned int iNPixe
 		
 		// initialise the pedvars variables
 		iped_cal2.clear();
-		iped_histo.clear();
+		iped_histo2.clear();
 		for( unsigned int p = 0; p < fNPixel; p++ )
 		{
 			iped_cal.clear();
@@ -172,7 +172,7 @@ bool VPedestalCalculator::initialize( bool ibCalibrationRun, unsigned int iNPixe
 			for( int w = 0; w < fSumWindow; w++ )
 			{
 				iped_cal.push_back( 0. );
-				sprintf( hname, "hped_cal_%d_%d_%d", i, p, w );
+				sprintf( hname, "hped_cal_%d_%d_%d", t + 1, p, w );
 				iped_histo.push_back( new TH1F(
 										  hname, "",
 										  i_hist_nbin, i_hist_xmin, i_hist_xmax ) );

--- a/src/VPlotAnasumHistograms.cpp
+++ b/src/VPlotAnasumHistograms.cpp
@@ -645,10 +645,9 @@ void VPlotAnasumHistograms::plot_CorrelatedSkyPlots()
  *
  *
  */
-TCanvas* VPlotAnasumHistograms::plot_theta2( double t2min, double t2max, int irbin )
+TCanvas* VPlotAnasumHistograms::plot_theta2( double t2min, double t2max, int irbin, double setYMax, double setYMin )
 {
 	// int iPlotPSF = 0;
-	double setYMax = -1.;
 	
 	char hname[200];
 	char htitle[200];
@@ -664,28 +663,23 @@ TCanvas* VPlotAnasumHistograms::plot_theta2( double t2min, double t2max, int irb
 	
 	// canvas that will contain the theta2 and the theta2_diff plots
 	TCanvas* c_t2 = 0;
+	TCanvas* c_t2_diff = 0;
 	
 	if( htheta2_diff && htheta2_on && htheta2_off )
 	{
 		sprintf( hname, "c_t2_%d", fRunNumber );
 		sprintf( htitle, "theta2 (run %d)", fRunNumber );
-		c_t2 = new TCanvas( hname, htitle, 10, 10, 900, 400 );
-		c_t2->Divide( 2, 1 );
-		//c_t2->SetLeftMargin( 0.12 );
+		c_t2 = new TCanvas( hname, htitle, 10, 10, 400, 400 );
+		sprintf( hname, "c_t2_diff_%d", fRunNumber );
+		c_t2_diff = new TCanvas( hname, htitle, 410, 10, 400, 400 );
+		c_t2_diff->SetLeftMargin( 0.12 );
 		
-		c_t2->cd( 1 );
+		c_t2->cd();
 		htheta2_on->SetXTitle( "#Theta^{2} [deg^{2}]" );
 		htheta2_on->SetTitle( "" );
 		htheta2_off->SetTitle( "#Theta^{2} Histogram" );
 		htheta2_off->SetTitle( "" );
-		if( setYMax < 0. )
-		{
-			htheta2_off->SetMaximum( htheta2_on->GetMaximum() * 1.1 );
-		}
-		else
-		{
-			htheta2_off->SetMaximum( setYMax );
-		}
+		htheta2_off->SetMaximum( htheta2_on->GetMaximum() * 1.1 );
 		sprintf( hname, "Number of events / %.3f deg^{2}", htheta2_off->GetXaxis()->GetBinWidth( 2 ) );
 		htheta2_on->SetYTitle( hname );
 		htheta2_off->SetYTitle( hname );
@@ -716,15 +710,24 @@ TCanvas* VPlotAnasumHistograms::plot_theta2( double t2min, double t2max, int irb
 			}
 		}
 		
-		c_t2->cd( 2 );
-		htheta2_diff->SetFillColor( 8 );
+		c_t2_diff->cd();
+		htheta2_diff->SetFillColor( 418 );
 		htheta2_diff->SetXTitle( "#Theta^{2} [deg^{2}]" );
 		htheta2_diff->SetTitle( "" );
 		sprintf( hname, "Number of events / %.3f deg^{2}", htheta2_diff->GetXaxis()->GetBinWidth( 2 ) );
 		htheta2_diff->SetYTitle( hname );
-		htheta2_diff->GetYaxis()->SetTitleOffset( 1.4 );
-		setHistogramPlottingStyle( htheta2_diff, 1, 2, 1, 1, irbin, 1001 );
+		htheta2_diff->GetYaxis()->SetTitleOffset( 1.6 );
+		setHistogramPlottingStyle( htheta2_diff, 418, 2, 1, 1, irbin, 1001 );
 		htheta2_diff->SetAxisRange( t2min, t2max );
+		if( setYMax > -999. )
+		{
+			htheta2_diff->SetMaximum( setYMax );
+		}
+		if( setYMin > -999. )
+		{
+			htheta2_diff->SetMinimum( setYMin );
+		}
+		
 		htheta2_diff->Draw( "hist e" );
 		
 		
@@ -757,7 +760,7 @@ TCanvas* VPlotAnasumHistograms::plot_theta2( double t2min, double t2max, int irb
 		cout << "histograms not found" << endl;
 	}
 	
-	return c_t2;
+	return c_t2_diff;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -291,7 +291,7 @@ bool VTableLookupDataHandler::getNextEvent( bool bShort )
 int VTableLookupDataHandler::fillNextEvent( bool bShort )
 {
 	///////////////////////////////////////////////////////////////////////////////
-	// read partical event for quick reconstruction quality assessment
+	// read partial event for quick reconstruction quality assessment
 	if( !fshowerpars->GetEntry( fEventCounter ) )
 	{
 		return -1;
@@ -1913,10 +1913,10 @@ void VTableLookupDataHandler::writeDeadTimeHistograms()
 			TDirectoryFile* iDeadtimeDirectory = ( TDirectoryFile* )f->Get( "deadTimeHistograms" );
 			if( iDeadtimeDirectory )
 			{
+				fDeadTime->readHistograms( iDeadtimeDirectory );
 				fDeadTime->calculateDeadTime();
 				fDeadTime->printDeadTime();
 				fDeadTime->writeHistograms();
-				fDeadTime->readHistograms( iDeadtimeDirectory );
 			}
 		}
 	}


### PR DESCRIPTION
Following changes with respect to alpha.12:

- critical bug fix for dead time calculation (dead time is set to zero in anasum due to missing scalar histograms)
- critical bug fix in time dependent pedvar68 (68% containment calculation)
- improved theta2 plotting 