### PR TITLE
v490 - alpha.17 - fine tuning of TMVA gamma/hadron separation

### DIFF
--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -312,6 +312,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 		{
 			return fDBTextDirectory;
 		}
+		string       getInstrumentATMString();
 		string       getInstrumentEpoch( bool iMajor = false,
 										 bool iUpdateInstrumentEpoch = false );
 		bool         isMC()
@@ -332,6 +333,6 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 			return ( fDBTextDirectory.size() > 0 );
 		}
 		
-		ClassDef( VEvndispRunParameter, 2005 ); //(increase this number)
+		ClassDef( VEvndispRunParameter, 2006 ); //(increase this number)
 };
 #endif

--- a/inc/VGammaHadronCuts.h
+++ b/inc/VGammaHadronCuts.h
@@ -129,7 +129,6 @@ class VGammaHadronCuts : public VAnalysisUtilities
 		unsigned int    fTMVAWeightFileIndex_Emax;
 		unsigned int    fTMVAWeightFileIndex_Zmin;
 		unsigned int    fTMVAWeightFileIndex_Zmax;
-		double          fTMVAEnergyStepSize;
 		map< unsigned int, double > fTMVASignalEfficiency;
 		map< unsigned int, double > fTMVA_MVACut;
 		double          fTMVAProbabilityThreshold;
@@ -177,7 +176,7 @@ class VGammaHadronCuts : public VAnalysisUtilities
 		bool   initPhaseCuts( string iDir );
 		bool   initProbabilityCuts( int irun );
 		bool   initProbabilityCuts( string iDir );
-		bool   initTMVAEvaluator( string iTMVAFile, unsigned int iTMVAWeightFileIndex_Emin, unsigned int iTMVAWeightFileIndex_Emax, unsigned int iTMVAWeightFileIndex_Zmin, unsigned int iTMVAWeightFileIndex_Zmax, double iTMVAEnergy_StepSize );
+		bool   initTMVAEvaluator( string iTMVAFile, unsigned int iTMVAWeightFileIndex_Emin, unsigned int iTMVAWeightFileIndex_Emax, unsigned int iTMVAWeightFileIndex_Zmin, unsigned int iTMVAWeightFileIndex_Zmax );
 		string getTelToAnalyzeString();
 		
 		
@@ -432,6 +431,6 @@ class VGammaHadronCuts : public VAnalysisUtilities
 			return fUseOrbitalPhaseCuts;
 		}
 		
-		ClassDef( VGammaHadronCuts, 58 );
+		ClassDef( VGammaHadronCuts, 59 );
 };
 #endif

--- a/inc/VInstrumentResponseFunctionRunParameter.h
+++ b/inc/VInstrumentResponseFunctionRunParameter.h
@@ -36,6 +36,7 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
 		
 		string          fCutFileName;
 		string          fInstrumentEpoch;
+		string          fInstrumentEpochATM;
 		vector< unsigned int > fTelToAnalyse;             // telescopes used in analysis (optional, not always filled)
 		int             fGammaHadronCutSelector;
 		int             fDirectionCutSelector;
@@ -100,12 +101,16 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
 		~VInstrumentResponseFunctionRunParameter() {}
 		
 		string                getInstrumentEpoch( bool iMajor = false );
+		string                getInstrumentATMString()
+		{
+			return fInstrumentEpochATM;
+		}
 		void                  print();
 		VMonteCarloRunHeader* readMCRunHeader();
 		bool                  readRunParameterFromTextFile( string iFile );
 		bool                  testRunparameters();
 		
-		ClassDef( VInstrumentResponseFunctionRunParameter, 16 );
+		ClassDef( VInstrumentResponseFunctionRunParameter, 17 );
 };
 
 #endif

--- a/inc/VStereoAnalysis.h
+++ b/inc/VStereoAnalysis.h
@@ -220,7 +220,7 @@ class VStereoAnalysis
 		CData* fDataRun;
 		TTree* fDataRunTree;
 		TFile* fDataFile;
-		string fInstrumentEpoch;
+		string fInstrumentEpochMinor;
 		vector< unsigned int > fTelToAnalyze;
 		
 		vector< VSkyCoordinates* > fAstro;        //!< Astronomical source parameters for this analysis

--- a/inc/VTMVAEvaluator.h
+++ b/inc/VTMVAEvaluator.h
@@ -139,6 +139,7 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 		float    fCoreDist;
 		float    fImages_Ttype[VDST_MAXTELESCOPES];
 		float    fDispDiff;
+		float    fDispDiff_log10;
 		float    fDummy;
 		
 		bool     bPlotEfficiencyPlotsPerBin;

--- a/inc/VTMVAEvaluator.h
+++ b/inc/VTMVAEvaluator.h
@@ -192,7 +192,7 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 			return fTMVA_EvaluationResult;
 		}
 		bool   initializeWeightFiles( string iWeightFileName, unsigned int iWeightFileIndex_Emin, unsigned int iWeightFileIndex_Emax,
-									  unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax, double iEnergyStepSize = 0.2 );
+									  unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax );
 		bool   initializeDataStrutures( CData* iC );
 		bool   IsZombie()
 		{
@@ -249,7 +249,7 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 		}
 		void   setTMVAMethod( string iMethodName = "BDT" );
 		
-		ClassDef( VTMVAEvaluator, 32 );
+		ClassDef( VTMVAEvaluator, 33 );
 };
 
 #endif

--- a/inc/VTMVAEvaluator.h
+++ b/inc/VTMVAEvaluator.h
@@ -192,7 +192,7 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 			return fTMVA_EvaluationResult;
 		}
 		bool   initializeWeightFiles( string iWeightFileName, unsigned int iWeightFileIndex_Emin, unsigned int iWeightFileIndex_Emax,
-									  unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax, double iEnergyStepSize = 0.2, string iInstrumentEpoch = "noepoch" );
+									  unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax, double iEnergyStepSize = 0.2 );
 		bool   initializeDataStrutures( CData* iC );
 		bool   IsZombie()
 		{

--- a/inc/VTMVAEvaluator.h
+++ b/inc/VTMVAEvaluator.h
@@ -131,7 +131,6 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 		float    fMLR;
 		float    fEmissionHeight;
 		float    fEmissionHeightChi2_log10;
-		unsigned int fEnergyReconstructionMethod;
 		float    fEChi2S;
 		float    fEChi2S_log10;
 		float    fdES;
@@ -146,7 +145,6 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 		bool     fPrintPlotting;
 		
 		TH1F*            getEfficiencyHistogram( string iName, TFile* iF, string iMethodTag_2 );
-		double           getMeanEnergyAfterCut( TFile* f, double iCut, unsigned int iDataBin );
 		bool             optimizeSensitivity( unsigned int iDataBin );
 		TGraph*          fillfromGraph2D( TObject* i_G, double i_ze_min, double i_ze_max );
 		void             fillTMVAEvaluatorResults();

--- a/inc/VTMVARunData.h
+++ b/inc/VTMVARunData.h
@@ -36,6 +36,8 @@ class VTMVARunData : public TNamed
 	
 		bool              fDebug;
 		
+		bool         fillEnergyCutData(
+			vector< double > iEnergyCut_Log10TeV_min, vector< double > iEnergyCut_Log10TeV_max );
 		unsigned int getTrainOptionValue( string iVarName, unsigned int i_default );
 		
 	public:
@@ -112,7 +114,7 @@ class VTMVARunData : public TNamed
 		void shuffleFileVectors();
 		void updateTrainingEvents( string iVarName, unsigned int iNEvents );
 		
-		ClassDef( VTMVARunData, 10 );
+		ClassDef( VTMVARunData, 11 );
 };
 
 #endif

--- a/macros/VTS/optimizeBDTcuts.C
+++ b/macros/VTS/optimizeBDTcuts.C
@@ -46,7 +46,7 @@ void optimizeBDTcuts(
 		iFullWeightFileName.str(),
 		weightFileIndex_Emin, weightFileIndex_Emax,
 		weightFileIndex_Zmin, weightFileIndex_Zmax,
-		-1, "VTS" );
+		-1 );
 		
 	// plotting
 	a.plotSignalAndBackgroundEfficiencies();

--- a/macros/VTS/optimizeBDTcuts.C
+++ b/macros/VTS/optimizeBDTcuts.C
@@ -4,7 +4,7 @@
  * pre-cuts (e.g., ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat)
  *
  * usage: e.g.
- * root -l -q -b 'optimizeBDTcuts.C("../../tmva/rates.root", "../../tmva", 0, 3, 0, 2)'
+ * root -l -q -b 'optimizeBDTcuts.C("../../tmva/rates.root", "../../tmva", "V6", 0, 3, 0, 2)'
  *
 */
 
@@ -23,6 +23,7 @@ void help()
 void optimizeBDTcuts(
 	string rateFile = "rates.root",
 	string weightFileDir = "./",
+    string epoch = "V6",
 	int weightFileIndex_Emin = 0, int weightFileIndex_Emax = 3,
 	int weightFileIndex_Zmin = 0., int weightFileIndex_Zmax = 3.,
 	double observing_time_h = 10.,
@@ -52,5 +53,5 @@ void optimizeBDTcuts(
 	
 	// print results to screen
 	a.printSignalEfficiency();
-	a.printOptimizedMVACutValues( "V6" );
+	a.printOptimizedMVACutValues( epoch );
 }

--- a/macros/VTS/optimizeBDTcuts.C
+++ b/macros/VTS/optimizeBDTcuts.C
@@ -4,7 +4,7 @@
  * pre-cuts (e.g., ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat)
  *
  * usage: e.g.
- * root -l -q -b 'optimizeBDTcuts.C("../../tmva/rates.root", "../../tmva", 0, 3, 0, 1)'
+ * root -l -q -b 'optimizeBDTcuts.C("../../tmva/rates.root", "../../tmva", 0, 3, 0, 2)'
  *
 */
 

--- a/macros/VTS/optimizeBDTcuts.C
+++ b/macros/VTS/optimizeBDTcuts.C
@@ -45,8 +45,7 @@ void optimizeBDTcuts(
 	a.initializeWeightFiles(
 		iFullWeightFileName.str(),
 		weightFileIndex_Emin, weightFileIndex_Emax,
-		weightFileIndex_Zmin, weightFileIndex_Zmax,
-		-1 );
+		weightFileIndex_Zmin, weightFileIndex_Zmax );
 		
 	// plotting
 	a.plotSignalAndBackgroundEfficiencies();

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -1048,3 +1048,12 @@ unsigned int VEvndispRunParameter::getAtmosphereID( bool iUpdateInstrumentEpoch 
 	
 	return fAtmosphereID;
 }
+
+string VEvndispRunParameter::getInstrumentATMString()
+{
+	ostringstream i_temp;
+	i_temp << getInstrumentEpoch( false );
+	i_temp << "_ATM" << getAtmosphereID();
+	
+	return i_temp.str();
+}

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -415,7 +415,7 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 				if( !( is_stream >> std::ws ).eof() )
 				{
 					is_stream >> temp;
-					if( temp != fInstrumentEpoch )
+					if( fInstrumentEpoch.size() > 1 && temp != fInstrumentEpoch.substr( 0, 2 ) )
 					{
 						i_useTheseCuts = false;
 					}
@@ -563,7 +563,7 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 				if( !( is_stream >> std::ws ).eof() )
 				{
 					is_stream >> temp;
-					if( temp == fInstrumentEpoch )
+					if( fInstrumentEpoch.size() > 1 && temp != fInstrumentEpoch.substr( 0, 2 ) )
 					{
 						fCut_SizeSecondMax_min = isize_min;
 						fCut_SizeSecondMax_max = isize_max;
@@ -595,7 +595,7 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 				if( !( is_stream >> std::ws ).eof() )
 				{
 					is_stream >> temp;
-					if( temp == fInstrumentEpoch )
+					if( fInstrumentEpoch.size() > 0 && temp == fInstrumentEpoch.substr( 0, 2 ) )
 					{
 						while( !( is_stream >> std::ws ).eof() )
 						{
@@ -633,6 +633,12 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 							{
 								is_stream >> iWeightFileDirectory;
 							}
+							if( fInstrumentEpoch.size() > 1 )
+							{
+								iWeightFileDirectory.replace(
+									iWeightFileDirectory.find( fInstrumentEpoch.substr( 0, 1 ) ),
+									2, fInstrumentEpoch );
+							}
 							string iWeightFileName;
 							if( !( is_stream >> std::ws ).eof() )
 							{
@@ -655,11 +661,6 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 							fTMVAWeightFile += iWeightFileName;
 							break;
 						}
-					}
-					else if( iPrint != 0 )
-					{
-						cout << "VGammaHadronCuts::readCuts: skipping TMVAPARAMETER due to epoch mismatch:";
-						cout << " required: " << fInstrumentEpoch << ", is: " << temp << endl;
 					}
 				}
 			}
@@ -752,7 +753,6 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 						}
 					}
 				}
-				////////////////////////////////////////////////////////////////////////////////////////////////////
 			}
 			////////////////////////////////////////////////////////////////////////////////////////////////////
 			// direction cut values
@@ -1747,7 +1747,7 @@ bool VGammaHadronCuts::initTMVAEvaluator( string iTMVAFile,
 	fTMVAEvaluator->setTMVAMethod( fTMVA_MVAMethod );
 	// read MVA weight files; set MVA cut values (e.g. find optimal values)
 	if( !fTMVAEvaluator->initializeWeightFiles( iTMVAFile, iTMVAWeightFileIndex_Emin, iTMVAWeightFileIndex_Emax,
-			iTMVAWeightFileIndex_Zmin, iTMVAWeightFileIndex_Zmax, iTMVAEnergy_StepSize, fInstrumentEpoch ) )
+			iTMVAWeightFileIndex_Zmin, iTMVAWeightFileIndex_Zmax, iTMVAEnergy_StepSize ) )
 	{
 		cout << "VGammaHadronCuts::initTMVAEvaluator: error while initializing TMVA weight files" << endl;
 		cout << "exiting... " << endl;

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -92,7 +92,6 @@ VGammaHadronCuts::VGammaHadronCuts()
 	fTMVAWeightFileIndex_Emax = 0;
 	fTMVAWeightFileIndex_Zmin = 0;
 	fTMVAWeightFileIndex_Zmax = 0;
-	fTMVAEnergyStepSize = 0.2;
 	fTMVAWeightFile = "";
 	fTMVASignalEfficiency.clear();
 	fTMVA_MVACut.clear();
@@ -619,14 +618,6 @@ bool VGammaHadronCuts::readCuts( string i_cutfilename, int iPrint )
 							if( !( is_stream >> std::ws ).eof() )
 							{
 								is_stream >> fTMVAWeightFileIndex_Zmax;
-							}
-							if( !( is_stream >> std::ws ).eof() )
-							{
-								if( !( is_stream >> fTMVAEnergyStepSize ) )
-								{
-									cout << "VGammaHadronCuts::readCuts: missing TMVAPARAMETER energy step size  " << endl;
-									break;
-								}
 							}
 							string iWeightFileDirectory;
 							if( !( is_stream >> std::ws ).eof() )
@@ -1669,7 +1660,7 @@ void VGammaHadronCuts::initializeCuts( int irun, string iFile )
 	{
 		if( !initTMVAEvaluator( fTMVAWeightFile,
 								fTMVAWeightFileIndex_Emin, fTMVAWeightFileIndex_Emax,
-								fTMVAWeightFileIndex_Zmin, fTMVAWeightFileIndex_Zmax, fTMVAEnergyStepSize ) )
+								fTMVAWeightFileIndex_Zmin, fTMVAWeightFileIndex_Zmax ) )
 		{
 			cout << "VGammaHadronCuts::initializeCuts: failed setting TMVA reader for " << fTMVAWeightFile;
 			cout << "(" << fTMVAWeightFileIndex_Emin << "," << fTMVAWeightFileIndex_Emax << ")" << endl;
@@ -1704,7 +1695,7 @@ void VGammaHadronCuts::initializeCuts( int irun, string iFile )
  */
 bool VGammaHadronCuts::initTMVAEvaluator( string iTMVAFile,
 		unsigned int iTMVAWeightFileIndex_Emin, unsigned int iTMVAWeightFileIndex_Emax,
-		unsigned int iTMVAWeightFileIndex_Zmin, unsigned int iTMVAWeightFileIndex_Zmax,  double iTMVAEnergy_StepSize )
+		unsigned int iTMVAWeightFileIndex_Zmin, unsigned int iTMVAWeightFileIndex_Zmax )
 {
 	TDirectory* cDir = gDirectory;
 	
@@ -1747,7 +1738,7 @@ bool VGammaHadronCuts::initTMVAEvaluator( string iTMVAFile,
 	fTMVAEvaluator->setTMVAMethod( fTMVA_MVAMethod );
 	// read MVA weight files; set MVA cut values (e.g. find optimal values)
 	if( !fTMVAEvaluator->initializeWeightFiles( iTMVAFile, iTMVAWeightFileIndex_Emin, iTMVAWeightFileIndex_Emax,
-			iTMVAWeightFileIndex_Zmin, iTMVAWeightFileIndex_Zmax, iTMVAEnergy_StepSize ) )
+			iTMVAWeightFileIndex_Zmin, iTMVAWeightFileIndex_Zmax ) )
 	{
 		cout << "VGammaHadronCuts::initTMVAEvaluator: error while initializing TMVA weight files" << endl;
 		cout << "exiting... " << endl;

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -940,23 +940,23 @@ void VGammaHadronCuts::printCutSummary()
 	{
 		cout << "Shape cuts: ";
 		cout << fCut_MSCW_min << " < MSCW < " << fCut_MSCW_max;
-		cout << ", " << fCut_MSCL_min << " < MSCL < " << fCut_MSCL_max << ", ";
+		cout << ", " << fCut_MSCL_min << " < MSCL < " << fCut_MSCL_max << endl;
 	}
 	// mean cuts
 	else if( fGammaHadronCutSelector % 10 == 1 )
 	{
 		cout << "Shape cuts: ";
 		cout << fCut_MeanImageWidth_min  << " < mean width < " << fCut_MeanImageWidth_max;
-		cout << ", " << fCut_MeanImageLength_min << " < mean length < " << fCut_MeanImageLength_max << ", ";
+		cout << ", " << fCut_MeanImageLength_min << " < mean length < " << fCut_MeanImageLength_max << endl;
 	}
 	// mean scaled cuts
 	else if( fGammaHadronCutSelector % 10 == 3 )
 	{
 		cout << "Shape cuts: ";
 		cout << fCut_MSW_min << " < MWR < " << fCut_MSW_max;
-		cout << ", " << fCut_MSL_min << " < MLR < " << fCut_MSL_max << ", ";
+		cout << ", " << fCut_MSL_min << " < MLR < " << fCut_MSL_max << endl;
 	}
-	cout << "average core distance < " << fCut_AverageCoreDistanceToTelescopes_max << " m";
+	cout << "Average core distance < " << fCut_AverageCoreDistanceToTelescopes_max << " m";
 	cout << " (max distance to telescopes (mintel) " << fCut_MinimumCoreDistanceToTelescopes_max << " m)";
 	// probability cuts
 	if( fGammaHadronCutSelector / 10 >= 1 && fGammaHadronCutSelector / 10 <= 3 )

--- a/src/VInstrumentResponseFunctionRunParameter.cpp
+++ b/src/VInstrumentResponseFunctionRunParameter.cpp
@@ -471,6 +471,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameters( string ifilenam
 	{
 		fObservatory = i_runPara->getObservatory();
 		fInstrumentEpoch = i_runPara->fInstrumentEpoch;
+		fInstrumentEpochATM = i_runPara->getInstrumentATMString();
 		fTelToAnalyse = i_runPara->fTelToAnalyze;
 	}
 	else
@@ -478,6 +479,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameters( string ifilenam
 		cout << "VInstrumentResponseFunctionRunParameter::readRunParameters() warning: cannot read instrument epoch and active telecopes from MC event file" << endl;
 		cout << "this might lead to a wrong choice in the gamma/hadron cuts - please check" << endl;
 		fInstrumentEpoch = "NOT_FOUND";
+		fInstrumentEpochATM = "NOT_FOUND";
 	}
 	// get NSB (pedvar) level
 	VTableLookupRunParameter* fR = ( VTableLookupRunParameter* )iFile->Get( "TLRunParameter" );
@@ -606,7 +608,9 @@ void VInstrumentResponseFunctionRunParameter::print()
 	}
 	if( fInstrumentEpoch != "NOT_SET" )
 	{
-		cout << "Instrument epoch: " << fInstrumentEpoch << endl;
+		cout << "Instrument epoch: " << fInstrumentEpoch;
+		cout << " (" << fInstrumentEpochATM << ")";
+		cout << endl;
 	}
 	else
 	{

--- a/src/VStereoAnalysis.cpp
+++ b/src/VStereoAnalysis.cpp
@@ -11,7 +11,7 @@ VStereoAnalysis::VStereoAnalysis( bool ion, string i_hsuffix, VAnaSumRunParamete
 	fDebug = false;
 	
 	fDataFile = 0;
-	fInstrumentEpoch = "NOT_SET";
+	fInstrumentEpochMinor = "NOT_SET";
 	fDirTot = iDirTot;
 	fDirTotRun = iDirRun;
 	bTotalAnalysisOnly = iTotalAnalysisOnly;
@@ -1822,7 +1822,7 @@ void VStereoAnalysis::setCuts( VAnaSumRunParameterDataClass iL, int irun )
 		else
 		{
 			fCuts->setNTel( iL.fMaxTelID );
-			fCuts->setInstrumentEpoch( fInstrumentEpoch );
+			fCuts->setInstrumentEpoch( fInstrumentEpochMinor );
 			fCuts->setTelToAnalyze( fTelToAnalyze );
 			fCuts->readCuts( iL.fCutFile );
 			fCuts->setTheta2Cut( iL.fSourceRadius );
@@ -1969,7 +1969,7 @@ CData* VStereoAnalysis::getDataFromFile( int i_runNumber )
 		VEvndispRunParameter* i_runPara = ( VEvndispRunParameter* )fDataFile->Get( "runparameterV2" );
 		if( i_runPara )
 		{
-			fInstrumentEpoch = i_runPara->getInstrumentEpoch( true );
+			fInstrumentEpochMinor = i_runPara->getInstrumentATMString();
 			fTelToAnalyze = i_runPara->fTelToAnalyze;
 		}
 		else
@@ -1977,7 +1977,7 @@ CData* VStereoAnalysis::getDataFromFile( int i_runNumber )
 			cout << "VStereoAnalysis::getDataFromFile() warning: epoch of current file " << endl;
 			cout << "and active telescope combination cannot be determined; " << endl;
 			cout << "this might lead to a wrong choice in the gamma/hadron cuts - please check" << endl;
-			fInstrumentEpoch = "NOT_FOUND";
+			fInstrumentEpochMinor = "NOT_FOUND";
 		}
 	}
 	return c;

--- a/src/VTMVAEvaluator.cpp
+++ b/src/VTMVAEvaluator.cpp
@@ -34,6 +34,7 @@ void VTMVAEvaluator::reset()
 	fSizeSecondMax_log10 = 0;
 	fCoreDist = 0.;
 	fDispDiff = 0.;
+	fDispDiff_log10 = 0.;
 	fDummy = 0.;
 	for( int i = 0; i < VDST_MAXTELESCOPES; i++ )
 	{
@@ -505,6 +506,10 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
 			{
 				fTMVAData[b]->fTMVAReader->AddVariable( "DispDiff", &fDispDiff );
 			}
+			else if( iTrainingVariables[t] == "log10(DispDiff)" && !iVariableIsASpectator[t] )
+			{
+				fTMVAData[b]->fTMVAReader->AddVariable( "log10(DispDiff)", &fDispDiff_log10 );
+			}
 			// Note: assume not more then 3 different telescope types
 			else if( iTrainingVariables[t] == "NImages_Ttype[0]" && !iVariableIsASpectator[t] )
 			{
@@ -777,6 +782,14 @@ bool VTMVAEvaluator::evaluate()
 		}
 		fCoreDist = sqrt( fData->Xcore * fData->Xcore + fData->Ycore * fData->Ycore );
 		fDispDiff = fData->DispDiff;
+		if( fDispDiff > 0. )
+		{
+			fDispDiff_log10 = log10( fDispDiff );
+		}
+		else
+		{
+			fDispDiff_log10 = 0.;    // !!! not clear what the best value is
+		}
 		if( fData->NTtype < VDST_MAXTELESCOPES )
 		{
 			for( int i = 0; i < fData->NTtype; i++ )

--- a/src/VTMVAEvaluator.cpp
+++ b/src/VTMVAEvaluator.cpp
@@ -569,7 +569,9 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
 	// smooth and interpolate
 	if( fParticleNumberFileName.size() > 0 && fSmoothAndInterpolateMVAValues )
 	{
-		smoothAndInterPolateMVAValue( 0, 0, iWeightFileIndex_Emin, iWeightFileIndex_Emax, iWeightFileIndex_Zmin, iWeightFileIndex_Zmax );
+		smoothAndInterPolateMVAValue( 0, 0,
+									  iWeightFileIndex_Emin, iWeightFileIndex_Emax,
+									  iWeightFileIndex_Zmin, iWeightFileIndex_Zmax );
 	}
 	
 	// print some info to screen
@@ -1294,8 +1296,11 @@ bool VTMVAEvaluator::optimizeSensitivity( unsigned int iDataBin )
 	cout << " ndif = " << Ndif << " (1 CU)" << endl;
 	cout << "VTVMAEvaluator::optimizeSensitivity event numbers: ";
 	cout << " (data bin " << iDataBin;
-	cout << ",  weighted mean energy " << TMath::Power( 10., fTMVAData[iDataBin]->fSpectralWeightedMeanEnergy_Log10TeV ) << " [TeV], ";
-	cout << fTMVAData[iDataBin]->fSpectralWeightedMeanEnergy_Log10TeV << ")";
+	cout << ",  weighted mean energy ";
+	cout << TMath::Power( 10., fTMVAData[iDataBin]->fSpectralWeightedMeanEnergy_Log10TeV ) << " [TeV], ";
+	cout << fTMVAData[iDataBin]->fSpectralWeightedMeanEnergy_Log10TeV << "), ";
+	cout << " Ebin [" << fTMVAData[iDataBin]->fEnergyCut_Log10TeV_min;
+	cout << ", " << fTMVAData[iDataBin]->fEnergyCut_Log10TeV_max << "]";
 	cout << endl;
 	
 	///////////////////////////////////////////////////////////////////

--- a/src/VTMVAEvaluator.cpp
+++ b/src/VTMVAEvaluator.cpp
@@ -154,7 +154,7 @@ string VTMVAEvaluator::getBDTFileName( string iWeightFileName, unsigned int i_E_
 bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
 		unsigned int iWeightFileIndex_Emin, unsigned int iWeightFileIndex_Emax,
 		unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax,
-		double iEnergyStepSize, string iInstrumentEpoch )
+		double iEnergyStepSize )
 {
 	//////////////////////////////
 	// sanity checks

--- a/src/VTMVAEvaluator.cpp
+++ b/src/VTMVAEvaluator.cpp
@@ -840,7 +840,7 @@ unsigned int VTMVAEvaluator::getDataBin( double iErec, double iZe )
 			}
 		}
 	}
-	//	if( fDebug && iBin < fTMVAData.size() )
+	if( fDebug && iBin < fTMVAData.size() )
 	{
 		cout << "VTMVAEvaluator::getDataBin: " << iBin << endl;
 		fTMVAData[iBin]->print();

--- a/src/VTMVARunData.cpp
+++ b/src/VTMVARunData.cpp
@@ -801,7 +801,7 @@ bool VTMVARunData::fillEnergyCutData(
 	vector< double > iEnergyCut_Log10TeV_max )
 {
 	// check sanity
-	if( iEnergyCut_Log10TeV_min.size() < 2 )
+	if( iEnergyCut_Log10TeV_min.size() < 1 )
 	{
 		cout << "VTMVARunData::readConfigurationFile error: need at least two energy bins ";
 		cout << iEnergyCut_Log10TeV_min.size() << endl;

--- a/src/VTMVARunData.cpp
+++ b/src/VTMVARunData.cpp
@@ -656,18 +656,29 @@ bool VTMVARunData::readConfigurationFile( char* iC )
 				}
 			}
 			// energy bins
+			if( temp == "ENERGYBINEDGES" )
+			{
+				vector< double > iEnergyCut_Log10TeV_min;
+				vector< double > iEnergyCut_Log10TeV_max;
+				
+				// read in energy bin
+				while( !( is_stream >> std::ws ).eof() )
+				{
+					double iT = 0.;
+					is_stream >> iT;
+					iEnergyCut_Log10TeV_min.push_back( iT );
+					is_stream >> iT;
+					iEnergyCut_Log10TeV_max.push_back( iT );
+				}
+				if( !fillEnergyCutData( iEnergyCut_Log10TeV_min, iEnergyCut_Log10TeV_max ) )
+				{
+					return false;
+				}
+			}
 			if( temp == "ENERGYBINS" )
 			{
 				vector< double > iEnergyCut_Log10TeV_min;
 				vector< double > iEnergyCut_Log10TeV_max;
-				vector< TCut > iEnergyCut;
-				
-				// energy reconstruction method (should be 1, unless you know it better)
-				unsigned int iEMethod;
-				if( !( is_stream >> std::ws ).eof() )
-				{
-					is_stream >> iEMethod;
-				}
 				
 				// read in energy bin
 				while( !( is_stream >> std::ws ).eof() )
@@ -678,12 +689,6 @@ bool VTMVARunData::readConfigurationFile( char* iC )
 				}
 				// sort
 				sort( iEnergyCut_Log10TeV_min.begin(), iEnergyCut_Log10TeV_min.end() );
-				// check sanity
-				if( iEnergyCut_Log10TeV_min.size() < 2 )
-				{
-					cout << "VTMVARunData::readConfigurationFile error: need at least two energy bins " << iEnergyCut_Log10TeV_min.size() << endl;
-					return false;
-				}
 				// fill maximum bins
 				for( unsigned int i = 1; i < iEnergyCut_Log10TeV_min.size(); i++ )
 				{
@@ -691,31 +696,9 @@ bool VTMVARunData::readConfigurationFile( char* iC )
 				}
 				// remove last minimum
 				iEnergyCut_Log10TeV_min.pop_back();
-				// fill cuts
-				for( unsigned int i = 0; i < iEnergyCut_Log10TeV_min.size(); i++ )
+				if( !fillEnergyCutData( iEnergyCut_Log10TeV_min, iEnergyCut_Log10TeV_max ) )
 				{
-					ostringstream iCut;
-					if( iEMethod == 0 )
-					{
-						iCut << "Erec>0.&&"  << iEnergyCut_Log10TeV_min[i]  <<  "<log10(Erec)&&log10(Erec)<" << iEnergyCut_Log10TeV_max[i];
-					}
-					else
-					{
-						iCut << "ErecS>0.&&" <<  iEnergyCut_Log10TeV_min[i] <<  "<log10(ErecS)&&log10(ErecS)<" << iEnergyCut_Log10TeV_max[i];
-					}
-					iEnergyCut.push_back( iCut.str().c_str() );
-				}
-				// filling everything into the energy data structure
-				fEnergyCutData.clear();
-				for( unsigned int i = 0; i < iEnergyCut_Log10TeV_min.size(); i++ )
-				{
-					fEnergyCutData.push_back( new VTMVARunDataEnergyCut() );
-					fEnergyCutData.back()->SetName( "fDataEnergyCut" );
-					fEnergyCutData.back()->fEnergyCutBin = 0;
-					fEnergyCutData.back()->fEnergyCut_Log10TeV_min = iEnergyCut_Log10TeV_min[i];
-					fEnergyCutData.back()->fEnergyCut_Log10TeV_max = iEnergyCut_Log10TeV_max[i];
-					fEnergyCutData.back()->fEnergyCut = iEnergyCut[i];
-					fEnergyCutData.back()->fEnergyReconstructionMethod = iEMethod;
+					return false;
 				}
 			}
 			// zenith angle bins (in [deg])
@@ -737,7 +720,8 @@ bool VTMVARunData::readConfigurationFile( char* iC )
 				// check sanity
 				if( iZenithCut_min.size() < 2 )
 				{
-					cout << "VTMVARunData::readConfigurationFile error: need at least one zenith bin " << iZenithCut_min.size() << endl;
+					cout << "VTMVARunData::readConfigurationFile error: need at least one zenith bin ";
+					cout << iZenithCut_min.size() << endl;
 					return false;
 				}
 				// fill maximum bins
@@ -810,4 +794,38 @@ VTableLookupRunParameter* VTMVARunData::getTLRunParameter()
 		return iP;
 	}
 	return 0;
+}
+
+bool VTMVARunData::fillEnergyCutData(
+	vector< double > iEnergyCut_Log10TeV_min,
+	vector< double > iEnergyCut_Log10TeV_max )
+{
+	// check sanity
+	if( iEnergyCut_Log10TeV_min.size() < 2 )
+	{
+		cout << "VTMVARunData::readConfigurationFile error: need at least two energy bins ";
+		cout << iEnergyCut_Log10TeV_min.size() << endl;
+		return false;
+	}
+	vector< TCut > iEnergyCut;
+	// fill cuts
+	for( unsigned int i = 0; i < iEnergyCut_Log10TeV_min.size(); i++ )
+	{
+		ostringstream iCut;
+		iCut << "ErecS>0.&&" <<  iEnergyCut_Log10TeV_min[i];
+		iCut <<  "<log10(ErecS)&&log10(ErecS)<" << iEnergyCut_Log10TeV_max[i];
+		iEnergyCut.push_back( iCut.str().c_str() );
+	}
+	// filling everything into the energy data structure
+	fEnergyCutData.clear();
+	for( unsigned int i = 0; i < iEnergyCut_Log10TeV_min.size(); i++ )
+	{
+		fEnergyCutData.push_back( new VTMVARunDataEnergyCut() );
+		fEnergyCutData.back()->SetName( "fDataEnergyCut" );
+		fEnergyCutData.back()->fEnergyCutBin = 0;
+		fEnergyCutData.back()->fEnergyCut_Log10TeV_min = iEnergyCut_Log10TeV_min[i];
+		fEnergyCutData.back()->fEnergyCut_Log10TeV_max = iEnergyCut_Log10TeV_max[i];
+		fEnergyCutData.back()->fEnergyCut = iEnergyCut[i];
+	}
+	return true;
 }

--- a/src/VTMVARunDataEnergyCut.cpp
+++ b/src/VTMVARunDataEnergyCut.cpp
@@ -1,7 +1,6 @@
 /*! \class VTMVARunDataEnergyCut
     \brief  VTMVARunDataEnergyCut data class for TMVA energy cuts
 
-
 */
 
 #include "VTMVARunDataEnergyCut.h"
@@ -23,5 +22,3 @@ void VTMVARunDataEnergyCut::print()
 	cout << " method " << fEnergyReconstructionMethod << endl;
 	cout << "\t cuts: " << fEnergyCut.GetTitle() << endl;
 }
-
-

--- a/src/calculateCrabRateFromMC.cpp
+++ b/src/calculateCrabRateFromMC.cpp
@@ -16,6 +16,7 @@
 #include "VMonteCarloRateCalculator.h"
 
 #include <iostream>
+#include <utility>
 #include <vector>
 
 
@@ -93,11 +94,40 @@ vector< double > read_zenith_bins( string fEffAreaFile )
 	return tmp_zebin_edges;
 }
 
+vector< pair< double, double > > read_energy_minmax_pairs(
+	vector< double > tmp_ebins_histo, string iEnergyKeyWord )
+{
+	vector< pair< double, double > > e;
+	if( tmp_ebins_histo.size() > 1 )
+	{
+		if( iEnergyKeyWord == "ENERGYBINS" )
+		{
+			for( unsigned int i = 0; i < tmp_ebins_histo.size() - 1; i++ )
+			{
+				e.push_back( make_pair( tmp_ebins_histo[i], tmp_ebins_histo[i + 1] ) );
+			}
+		}
+		else
+		{
+			for( unsigned int i = 0; i < tmp_ebins_histo.size(); i += 2 )
+			{
+				e.push_back( make_pair( tmp_ebins_histo[i], tmp_ebins_histo[i + 1] ) );
+			}
+		}
+	}
+	return e;
+}
+
+
 /*
  * read energy bin vector from TMVA run parameter file
  *
+ * ENERGYBINEDGES -1.5 -0.5 -1. 0. -0.5 0.5 0.0 1. 0.5 2.0
+ * ENERGYBINS -1.50 -0.75 -0.25 0.5 2.0
  */
-vector< double > read_energy_bins( string iTMVAParameterFile )
+vector< double > read_energy_bins(
+	string iTMVAParameterFile,
+	string iEnergyKeyWord )
 {
 	vector< double > tmp_e;
 	ifstream is( iTMVAParameterFile.c_str(), ifstream::in );
@@ -126,9 +156,8 @@ vector< double > read_energy_bins( string iTMVAParameterFile )
 			continue;
 		}
 		is_stream >> temp;
-		if( temp == "ENERGYBINS" )
+		if( temp == iEnergyKeyWord )
 		{
-			is_stream >> temp;
 			while( !( is_stream >> std::ws ).eof() )
 			{
 				double iT = 0.;
@@ -139,14 +168,29 @@ vector< double > read_energy_bins( string iTMVAParameterFile )
 	}
 	is.close();
 	
-	cout << "Energy bins: ";
-	for( unsigned int e = 0; e < tmp_e.size(); e++ )
-	{
-		cout << tmp_e[e] << ", ";
-	}
-	cout << endl;
-	
 	return tmp_e;
+}
+
+/*
+ * convert overlapping pairs of energy bin definitions to non-overlapping
+ * for histogram definition
+ * Energy bins (rate calculation): [-1.5, -0.5], [-1, 0], [-0.5, 0.5], [0, 1], [0.5, 2],
+*/
+vector< double > read_energy_histo( vector< pair< double, double >> ebins )
+{
+	vector< double > e;
+	if( ebins.size() ==  0 )
+	{
+		return e;
+	}
+	e.push_back( ebins[0].first );
+	for( unsigned int i = 0; i < ebins.size() - 1; i++ )
+	{
+		e.push_back( 0.5 * ( ebins[i].first + ebins[i + 1].second ) );
+	}
+	e.push_back( ebins.back().second );
+	
+	return e;
 }
 
 /*
@@ -154,18 +198,10 @@ vector< double > read_energy_bins( string iTMVAParameterFile )
    - entry 0: MC rates from the Crab nebula
 
 */
-vector< TProfile2D* > initializeRateProfileHistos( string fEffAreaFile, string fTMVAParameterFile )
+vector< TProfile2D* > initializeRateProfileHistos(
+	string fEffAreaFile, string fTMVAParameterFile, vector< double > tmp_ebins )
 {
 	vector< TProfile2D* > h;
-	
-    /* TODO
-     * - allow to take overlapping energy bins into account
-     * - two types of bins:
-     *   - for histogram (non overlapping)
-     *   - for integration (possibly overlapping)
-     *
-     */
-	vector< double > tmp_ebins = read_energy_bins( fTMVAParameterFile );
 	
 	vector< double > tmp_zebin_edges = read_zenith_bins( fEffAreaFile );
 	
@@ -194,7 +230,12 @@ vector< TProfile2D* > initializeRateProfileHistos( string fEffAreaFile, string f
  * fill MC rates from effective area trees
  *
  */
-TTree* fillMCRates( string fEffAreaFile, TProfile2D* h, double fEnergyThreshold )
+TTree* fillMCRates(
+	string fEffAreaFile,
+	TProfile2D* h,
+	double fEnergyThreshold,
+	double fDeadTime,
+	vector< pair< double, double > > ebins )
 {
 	float ze = 0.;
 	int az = 0;
@@ -267,20 +308,21 @@ TTree* fillMCRates( string fEffAreaFile, TProfile2D* h, double fEnergyThreshold 
 		MCrate = fMCR->getMonteCarloRate(
 					 fenergy, feffectivearea,
 					 fWhippleIndex, fWhippleNorm, 1., fEnergyThreshold, 1.e7, false );
+		MCrate *= ( 1. - fDeadTime );
 		fMC->Fill();
 		
-		for( int e = 1; e <= h->GetXaxis()->GetNbins(); e++ )
+		for( unsigned int e = 0; e < ebins.size(); e++ )
 		{
 			fill_profilehistogram_for_TMVA(
 				h,
-				h->GetXaxis()->GetBinCenter( e ),
+				0.5 * ( ebins[e].first + ebins[e].second ),
 				ze,
 				fMCR->getMonteCarloRate(
 					fenergy, feffectivearea,
 					fWhippleIndex, fWhippleNorm, 1.,
-					TMath::Power( 10., h->GetXaxis()->GetBinLowEdge( e ) ),
-					TMath::Power( 10., h->GetXaxis()->GetBinUpEdge( e ) ),
-					false ) );
+					TMath::Power( 10., ebins[e].first ),
+					TMath::Power( 10., ebins[e].second ),
+					false ) * ( 1. - fDeadTime ) );
 		}
 	}
 	f->Close();
@@ -297,7 +339,7 @@ vector< string > read_run_list( string iRunList )
 	ifstream is( iRunList.c_str(), ifstream::in );
 	if( !is )
 	{
-		cout << "Error reading energy bins from list of background files files" << endl;
+		cout << "Error reading run list of background files" << endl;
 		cout << "exiting..." << endl;
 		exit( EXIT_FAILURE );
 	}
@@ -316,7 +358,10 @@ vector< string > read_run_list( string iRunList )
  *
  * assume that anasum files contain a single run only (!!)
  */
-void fillBackgroundRates_perRun( string i_runFileName, TProfile2D* h )
+void fillBackgroundRates_perRun(
+	string i_runFileName,
+	TProfile2D* h,
+	vector< pair< double, double > > ebins )
 {
 	TFile* f = new TFile( i_runFileName.c_str() );
 	if( f->IsZombie() )
@@ -348,7 +393,8 @@ void fillBackgroundRates_perRun( string i_runFileName, TProfile2D* h )
 		f->Close();
 		return;
 	}
-	cout << "RUN " << elevationOff << ", " << tOff << ", " << OffNorm << ", " << elevationOff << ", " << NOff << ", " << runOn << endl;
+	cout << "RUN " << elevationOff << ", " << tOff << ", " << OffNorm;
+	cout << ", " << elevationOff << ", " << NOff << ", " << runOn << endl;
 	stringstream iTemp;
 	iTemp << "run_" << runOn << "/stereo/energyHistograms/herecCounts_off";
 	TH1D* hOff = ( TH1D* )f->Get( iTemp.str().c_str() );
@@ -357,10 +403,10 @@ void fillBackgroundRates_perRun( string i_runFileName, TProfile2D* h )
 		cout << "Background rate file incomplete (missing off histogram)" << i_runFileName << endl;
 		return;
 	}
-	for( int e = 1; e <= h->GetXaxis()->GetNbins(); e++ )
+	for( unsigned int e = 0; e < ebins.size(); e++ )
 	{
-		int i_binStart = hOff->GetXaxis()->FindBin( h->GetXaxis()->GetBinLowEdge( e ) );
-		int i_binStop = hOff->GetXaxis()->FindBin( h->GetXaxis()->GetBinUpEdge( e ) );
+		int i_binStart = hOff->GetXaxis()->FindBin( ebins[e].first );
+		int i_binStop = hOff->GetXaxis()->FindBin( ebins[e].second );
 		double iR = 0.;
 		for( int b = i_binStart; b <= i_binStop; b++ )
 		{
@@ -369,7 +415,7 @@ void fillBackgroundRates_perRun( string i_runFileName, TProfile2D* h )
 		if( tOff > 0. && iR > 0. )
 		{
 			h->Fill(
-				h->GetXaxis()->GetBinCenter( e ),
+				0.5 * ( ebins[e].first + ebins[e].second ),
 				90. - elevationOff,
 				iR * OffNorm / tOff * 60. );
 		}
@@ -383,13 +429,13 @@ void fillBackgroundRates_perRun( string i_runFileName, TProfile2D* h )
  * fill background rates from anasum files
  *
  */
-void fillBackgroundRates( string iRunList, TProfile2D* h )
+void fillBackgroundRates( string iRunList, TProfile2D* h, vector< pair< double, double > > ebins )
 {
 	vector< string > i_runs =  read_run_list( iRunList );
 	
 	for( unsigned int i = 0; i < i_runs.size(); i++ )
 	{
-		fillBackgroundRates_perRun( i_runs[i], h );
+		fillBackgroundRates_perRun( i_runs[i], h, ebins );
 	}
 }
 
@@ -441,7 +487,7 @@ int main( int argc, char* argv[] )
 	if( argc != 6 )
 	{
 		cout << "VTS.calculateCrabRateFromMC <effective area file> <outputfile> ";
-		cout << "<energy threshold [TeV]> ";
+		cout << "<dead time (in percent: e.g., 15)";
 		cout << "<TMVA parameter file> ";
 		cout << "<run list for anasum background files>";
 		cout << endl << endl;
@@ -451,9 +497,10 @@ int main( int argc, char* argv[] )
 	
 	string fEffAreaFile = argv[1];
 	string ioffile = argv[2];
-	// energy threshold
-	double fEnergyThreshold = atof( argv[3] );
-	cout << "energy threshold: " << fEnergyThreshold << " TeV" << endl;
+	double fDeadTime = atof( argv[3] );
+	cout << "dead time (%): " << fDeadTime << endl;
+	double fEnergyThreshold = 0.01;
+	cout << "energy threshold (hardwired): " << fEnergyThreshold << " TeV" << endl;
 	if( fEnergyThreshold < 1.e-2 )
 	{
 		fEnergyThreshold = 1.e-2;    // take care of log(fEnergyThreshold)
@@ -469,15 +516,46 @@ int main( int argc, char* argv[] )
 		cout << "error opening output file: " << ioffile << endl;
 		exit( EXIT_SUCCESS );
 	}
+	// two types of energy binning
+	// - for rate integration (possibly overlapping bins used for TMVA
+	// training and evaluation)
+	// - for histogram definition (non-overlapping)
+	vector< double > tmp_ebins_histo = read_energy_bins( fTMVAParameterFile, "ENERGYBINS" );
+	vector< pair< double, double > > tmp_ebins;
+	if( tmp_ebins_histo.size() > 0 )
+	{
+		tmp_ebins = read_energy_minmax_pairs( tmp_ebins_histo, "ENERGYBINS" );
+	}
+	else
+	{
+		tmp_ebins = read_energy_minmax_pairs(
+						read_energy_bins( fTMVAParameterFile, "ENERGYBINEDGES" ), "ENERGYBINEDGES" );
+		tmp_ebins_histo = read_energy_histo( tmp_ebins );
+	}
+	
+	cout << "Energy bins (rate calculation): ";
+	for( unsigned int i = 0; i < tmp_ebins.size(); i++ )
+	{
+		cout << "[" << tmp_ebins[i].first << ", " << tmp_ebins[i].second << "], ";
+	}
+	cout << endl;
+	cout << "Energy bins (histogram): ";
+	for( unsigned int e = 0; e < tmp_ebins_histo.size(); e++ )
+	{
+		cout << tmp_ebins_histo[e] << ", ";
+	}
+	cout << endl;
 	
 	vector< TProfile2D* > hRateProfileHisto = initializeRateProfileHistos(
-				fEffAreaFile, fTMVAParameterFile );
+				fEffAreaFile, fTMVAParameterFile, tmp_ebins_histo );
 				
 	TTree* fMC = fillMCRates(
-					 fEffAreaFile, hRateProfileHisto[0], fEnergyThreshold );
+					 fEffAreaFile, hRateProfileHisto[0],
+					 fEnergyThreshold, fDeadTime,
+					 tmp_ebins );
 					 
 	fillBackgroundRates(
-		fBackgroundRunList, hRateProfileHisto[1] );
+		fBackgroundRunList, hRateProfileHisto[1], tmp_ebins );
 		
 	cout << "writing results to " << f1->GetName() << endl;
 	f1->cd();

--- a/src/calculateCrabRateFromMC.cpp
+++ b/src/calculateCrabRateFromMC.cpp
@@ -148,8 +148,9 @@ vector< double > read_energy_bins( string iTMVAParameterFile )
 	
 	return tmp_e;
 }
+
 /*
-  initialzie profile histograms rates as function of energy and zenith angle
+  initialize profile histograms rates as function of energy and zenith angle
    - entry 0: MC rates from the Crab nebula
 
 */
@@ -157,6 +158,13 @@ vector< TProfile2D* > initializeRateProfileHistos( string fEffAreaFile, string f
 {
 	vector< TProfile2D* > h;
 	
+    /* TODO
+     * - allow to take overlapping energy bins into account
+     * - two types of bins:
+     *   - for histogram (non overlapping)
+     *   - for integration (possibly overlapping)
+     *
+     */
 	vector< double > tmp_ebins = read_energy_bins( fTMVAParameterFile );
 	
 	vector< double > tmp_zebin_edges = read_zenith_bins( fEffAreaFile );

--- a/src/calculateCrabRateFromMC.cpp
+++ b/src/calculateCrabRateFromMC.cpp
@@ -308,7 +308,7 @@ TTree* fillMCRates(
 		MCrate = fMCR->getMonteCarloRate(
 					 fenergy, feffectivearea,
 					 fWhippleIndex, fWhippleNorm, 1., fEnergyThreshold, 1.e7, false );
-		MCrate *= ( 1. - fDeadTime );
+		MCrate *= ( 1. - fDeadTime / 100. );
 		fMC->Fill();
 		
 		for( unsigned int e = 0; e < ebins.size(); e++ )
@@ -322,7 +322,7 @@ TTree* fillMCRates(
 					fWhippleIndex, fWhippleNorm, 1.,
 					TMath::Power( 10., ebins[e].first ),
 					TMath::Power( 10., ebins[e].second ),
-					false ) * ( 1. - fDeadTime ) );
+					false ) * ( 1. - fDeadTime / 100. ) );
 		}
 	}
 	f->Close();

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -94,7 +94,7 @@ int main( int argc, char* argv[] )
 	fRunPara->print();
 	
 	/////////////////////////////////////////////////////////////////
-	// open output file and write results to dist
+	// open output file and write results to disk
 	TFile* fOutputfile = new TFile( fOutputfileName.c_str(), "RECREATE" );
 	if( fOutputfile->IsZombie() )
 	{
@@ -108,7 +108,7 @@ int main( int argc, char* argv[] )
 	VGammaHadronCuts* fCuts = new VGammaHadronCuts();
 	fCuts->initialize();
 	fCuts->setNTel( fRunPara->telconfig_ntel, fRunPara->telconfig_arraycentre_X, fRunPara->telconfig_arraycentre_Y );
-	fCuts->setInstrumentEpoch( fRunPara->getInstrumentEpoch( true ) );
+	fCuts->setInstrumentEpoch( fRunPara->getInstrumentATMString() );
 	fCuts->setTelToAnalyze( fRunPara->fTelToAnalyse );
 	if( !fCuts->readCuts( fRunPara->fCutFileName, 2 ) )
 	{

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -246,7 +246,7 @@ int main( int argc, char* argv[] )
 			if( fMC_histo )
 			{
 				fMC_histo->matchDataVectors( fRunPara->fAzMin, fRunPara->fAzMax, fRunPara->fSpectralIndex );
-				fMC_histo->print();
+				// fMC_histo->print();
 			}
 			else
 			{

--- a/src/makeRadialAcceptance.cpp
+++ b/src/makeRadialAcceptance.cpp
@@ -92,7 +92,7 @@ int main( int argc, char* argv[] )
 	
 	// read gamma/hadron cuts from cut file
 	VGammaHadronCuts* fCuts = new VGammaHadronCuts();
-	fCuts->setInstrumentEpoch( fInstrumentEpoch );
+	//	fCuts->setInstrumentEpoch( fInstrumentEpoch );
 	fCuts->setTelToAnalyze( teltoana );
 	fCuts->setNTel( ntel );
 	if( cutfilename.size() > 0 )
@@ -180,10 +180,12 @@ int main( int argc, char* argv[] )
 		}
 	}
 	
+	// loop over all files and fill acceptances
 	for( unsigned int i = 0; i < fRunPara->fRunList.size(); i++ )
 	{
 		sprintf( ifile, "%s/%d.mscw.root", datadir.c_str(), fRunPara->fRunList[i].fRunOff );
-		cout << "now chaining " << ifile << " (wobble offset " << -1.*fRunPara->fRunList[i].fWobbleNorth << ", " << fRunPara->fRunList[i].fWobbleWest << ")" << endl;
+		cout << "now chaining " << ifile;
+		cout << " (wobble offset " << -1.*fRunPara->fRunList[i].fWobbleNorth << ", " << fRunPara->fRunList[i].fWobbleWest << ")" << endl;
 		// test if file exists
 		TFile fTest( ifile );
 		if( fTest.IsZombie() )
@@ -197,31 +199,34 @@ int main( int argc, char* argv[] )
 		
 		// Check number of telescopes in run
 		VEvndispRunParameter* iParV2 = ( VEvndispRunParameter* )fTest.Get( "runparameterV2" );
-		if( iParV2 )
+		if( !iParV2 )
 		{
-			cout << "Testing telescope multiplicity " << teltoanastring << endl;
-			if( teltoana.size() != iParV2->fTelToAnalyze.size() || !equal( teltoana.begin(), teltoana.end(), iParV2->fTelToAnalyze.begin() ) )
+			cout << "Error reading run parameters " << endl;
+			continue;
+		}
+		cout << "Testing telescope multiplicity " << teltoanastring << endl;
+		if( teltoana.size() != iParV2->fTelToAnalyze.size() || !equal( teltoana.begin(), teltoana.end(), iParV2->fTelToAnalyze.begin() ) )
+		{
+			cout << endl;
+			cout << "error: Requested telescopes " << teltoanastring << " do not equal telescopes in run " << ifile << endl;
+			cout << "PAR ";
+			for( unsigned int i = 0; i < iParV2->fTelToAnalyze.size(); i++ )
 			{
-				cout << endl;
-				cout << "error: Requested telescopes " << teltoanastring << " do not equal telescopes in run " << ifile << endl;
-				cout << "PAR ";
-				for( unsigned int i = 0; i < iParV2->fTelToAnalyze.size(); i++ )
-				{
-					cout << iParV2->fTelToAnalyze[i] << "  ";
-				}
-				cout << endl;
-				cout << "USER ";
-				for( unsigned int i = 0; i < teltoana.size(); i++ )
-				{
-					cout << teltoana[i] << "  ";
-				}
-				cout << endl;
-				cout << "\t" << teltoana.size() << "\t" << iParV2->fTelToAnalyze.size() << endl;
-				exit( EXIT_FAILURE );
+				cout << iParV2->fTelToAnalyze[i] << "  ";
 			}
+			cout << endl;
+			cout << "USER ";
+			for( unsigned int i = 0; i < teltoana.size(); i++ )
+			{
+				cout << teltoana[i] << "  ";
+			}
+			cout << endl;
+			cout << "\t" << teltoana.size() << "\t" << iParV2->fTelToAnalyze.size() << endl;
+			exit( EXIT_FAILURE );
 		}
 		
 		// set gamma/hadron cuts
+		fCuts->setInstrumentEpoch( iParV2->getInstrumentATMString() );
 		fCuts->initializeCuts( fRunPara->fRunList[i].fRunOff, datadir );
 		// pointer to data tree
 		fCuts->setDataTree( d );

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -255,12 +255,12 @@ bool train( VTMVARunData* iRun,
 	}
 	if( iRun->fEnergyCutData.size() <= iEnergyBin || iRun->fOutputFile.size() <= iEnergyBin )
 	{
-		cout << "error in train: energy bin out of range " << iEnergyBin;
+		cout << "error during training: energy bin out of range " << iEnergyBin << endl;
 		return false;
 	}
 	if( iRun->fZenithCutData.size() < iZenithBin || iRun->fOutputFile[0].size() < iZenithBin )
 	{
-		cout << "error in train: zenith bin out of range " << iZenithBin;
+		cout << "error during training: zenith bin out of range " << iZenithBin << endl;
 		return false;
 	}
 	// quality cuts before training

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -154,6 +154,10 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
 				{
 					i_fraction_of_events_to_keep /= ( double )iTreeVector.size();
 				}
+				if( i_fraction_of_events_to_keep > 1. )
+				{
+					i_fraction_of_events_to_keep = 1.;
+				}
 				cout << "\t keeping " << i_fraction_of_events_to_keep * 100. << "\% of events of ";
 				if( iSignal )
 				{
@@ -326,9 +330,9 @@ bool train( VTMVARunData* iRun,
 		cout << "Error: failed preparing traing / testing trees" << endl;
 		return false;
 	}
-	if( iSignalTree_reduced->GetEntries()  == 0 || iBackgroundTree_reduced->GetEntries() == 0 )
+	if( iSignalTree_reduced->GetEntries() < 1000 || iBackgroundTree_reduced->GetEntries() < 1000 )
 	{
-		cout << "Error: no events available for training: ";
+		cout << "Error: less than 1000 events available for training: ";
 		cout << " signal (" << iSignalTree_reduced->GetEntries() << "), ";
 		cout << " background (" << iBackgroundTree_reduced->GetEntries() << ")" << endl;
 		return false;


### PR DESCRIPTION
Changes of this PR relative to alpha.17:
- improved setting of energy bins for TMVA gamma/hadron cut training and evaluation. Bins are now defined in overlapping energy bins, which provides a 'natural' smoothing of the cut selectors
- (minor epoch) dependent training and cut evaluation
- removal of obsolete code


