### PR TITLE
v490 - alpha.20

### DIFF
--- a/inc/VEnergyThreshold.h
+++ b/inc/VEnergyThreshold.h
@@ -4,14 +4,17 @@
 #define VEnergyThreshold_H
 
 #include "TCanvas.h"
+#include "TChain.h"
 #include "TF1.h"
 #include "TFile.h"
+#include "TGraph.h"
 #include "TGraphErrors.h"
 #include "TH1D.h"
+#include "TH2F.h"
 #include "TList.h"
 #include "TMath.h"
 #include "TObject.h"
-#include "TProfile.h"
+#include "TROOT.h"
 #include "TStyle.h"
 #include "TText.h"
 #include "TTree.h"
@@ -23,7 +26,6 @@
 #include <vector>
 
 #include "VRunList.h"
-#include "CEffArea.h"
 
 using namespace std;
 
@@ -34,7 +36,7 @@ class VEnergyThreshold : public TObject
 		bool fDebug;
 		
 		TFile* fEffAreaFile;
-		CEffArea* fEffArea;
+		TChain* fEffArea;
 		
 		TFile* fEnergyThresholdFile;
 		
@@ -44,30 +46,32 @@ class VEnergyThreshold : public TObject
 		TFile* fOutFile;
 		TTree* fTreeEth;
 		
-		double fze;
-		int fAzBin;
-		double fAzMin;
-		double fAzMax;
-		double fXoff;
-		double fYoff;
-		double fWoff;
-		int fTNoise;
-		double fTNoisePE;
-		double fTPedvar;
-		double fSpectralIndex;
-		double feth;
-		double fesys_10p;
-		double fesys_15p;
-		double fesys_20p;
-		double feffFract_05p;
-		double feffFract_10p;
-		double feffFract_20p;
-		double feffFract_50p;
-		double feffFract_90p;
-		// effective areas
-		double feff_300GeV;
-		double feff_500GeV;
-		double feff_1TeV;
+		float fze;
+		UShort_t fAzBin;
+		float fAzMin;
+		float fAzMax;
+		float fWoff;
+		UShort_t fTNoise;
+		float fTPedvar;
+		float feth;
+		float fesys_10p;
+		float fesys_15p;
+		float fesys_20p;
+		float feffFract_05p;
+		float feffFract_10p;
+		float feffFract_20p;
+		float feffFract_50p;
+		float feffFract_90p;
+		float feff_300GeV;
+		float feff_500GeV;
+		float feff_1TeV;
+		
+		UShort_t nbins;
+		float e0[1000];
+		float eff[1000];
+		UShort_t nbins_esys;
+		float e0_esys[1000];
+		float esys_rel[1000];
 		
 		int fPlottingMarkerStyle;
 		int fPlottingMarkerColor;
@@ -79,7 +83,6 @@ class VEnergyThreshold : public TObject
 		double getEnergyThreshold( TH1D* h = 0, bool bLogEnergyAxis = true, bool bFit = true );
 		bool openEnergyThresholdFile();
 		bool setUpThresholdTree();
-		void copyEntry();
 		
 		double interpolateEnergyThreshold( VRunList* );
 		
@@ -92,13 +95,14 @@ class VEnergyThreshold : public TObject
 		bool closeOutputFile();
 		bool openEffectiveAreaFile( string ifile );
 		bool calculateEnergyThreshold( bool bFit = true, int nentries = -1 );
-		double getEnergy_maxSystematic( TObject* h = 0, double iSys = 0.1 );
+		double getEnergy_maxSystematic( vector< double > x, vector< double > y, double iSys = 0.1 );
+		double getEnergy_maxSystematic( TGraphErrors* g, double iSys = 0.1 );
 		double getEnergy_MaxEffectiveAreaFraction( TObject* h = 0, double iFrac = 0.1 );
 		double getEnergy_fixedValue()
 		{
 			return fEnergyThresholdFixedValue;
 		}
-		void plot_energyThresholds( string var = "E_diffmax", double ze = 20., double woff = 0.5, int noise = 150, double index = 2.4, int az = 16, bool bPlot = true, string plot_option = "p" );
+		void plot_energyThresholds( string var = "E_diffmax", double ze = 20., double woff = 0.5, int noise = 150, int az = 16, bool bPlot = true, string plot_option = "p" );
 		void setPlottingStyle( int iC = 1, int iS = 21, float iW = 2., float iL = 2. )
 		{
 			fPlottingMarkerStyle = iS;

--- a/inc/VTMVAEvaluator.h
+++ b/inc/VTMVAEvaluator.h
@@ -204,8 +204,9 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
 		{
 			fDebug = iB;
 		}
-		void   setSensitivityOptimizationParameters( double iSignificance = 5., double iMinEvents = 10., double iObservationTime_h = 50.,
-				double iMinBackgroundRateRatio = 1. / 5, double iMinBackgroundEvents = 0. )
+		void   setSensitivityOptimizationParameters(
+			double iSignificance = 5., double iMinEvents = 10., double iObservationTime_h = 50.,
+			double iMinBackgroundRateRatio = 1. / 5, double iMinBackgroundEvents = 0. )
 		{
 			fOptimizationSourceSignificance = iSignificance;
 			fOptimizationMinSignalEvents = iMinEvents;

--- a/macros/VTS/optimizeBDTcuts.C
+++ b/macros/VTS/optimizeBDTcuts.C
@@ -27,7 +27,8 @@ void optimizeBDTcuts(
 	int weightFileIndex_Emin = 0, int weightFileIndex_Emax = 3,
 	int weightFileIndex_Zmin = 0., int weightFileIndex_Zmax = 3.,
 	double observing_time_h = 5.,
-	double significance = 5. )
+	double significance = 5.,
+    double min_source_events = 10. )
 {
 	VTMVAEvaluator a;
 	
@@ -41,7 +42,8 @@ void optimizeBDTcuts(
     // - significance
     // - >= 10 signal events
     // - alpha = 1./5.
-	a.setSensitivityOptimizationParameters( significance, 10., observing_time_h, 1. / 5. );
+	a.setSensitivityOptimizationParameters( 
+            significance, min_source_events, observing_time_h, 1. / 5. );
     // maximum signal efficiency allowed
 	a.setSensitivityOptimizationFixedSignalEfficiency( 0.90 );
 	a.setSensitivityOptimizationMinSourceStrength( 0.00001 );

--- a/src/VEnergyThreshold.cpp
+++ b/src/VEnergyThreshold.cpp
@@ -37,7 +37,7 @@ iii)  plot energy thresholds
 // create a new instance, open the data file
 VEnergyThreshold a( 0.0, "myOutputFile.root" );
 
-// plot everything (for ze=20, wobble offset=0.5 deg, noise = 150, index = 2.4, az bin = 16)
+// plot everything (for ze=20, wobble offset=0.5 deg, noise = 150, az bin = 16)
 a.plot_energyThresholds( "E_diffmax", 20., 0.5, 150, 2.4, 16 );
 
 Energy thresholds are defined (currently) in 3 ways:
@@ -141,17 +141,32 @@ bool VEnergyThreshold::openEffectiveAreaFile( string iname )
 		cout << "VEnergyThreshold::openEffectiveAreaFile " << iname << endl;
 	}
 	
-	TChain* f = new TChain( "fEffArea" );
-	f->Add( iname.c_str() );
-	if( f->GetListOfFiles()->GetEntries() == 0 )
+	fEffArea = new TChain( "fEffAreaH2F" );
+	fEffArea->Add( iname.c_str() );
+	if( fEffArea->GetListOfFiles()->GetEntries() == 0 )
 	{
-		cout << "error opening " << iname << "(" << f->GetListOfFiles()->GetEntries() << ")" << endl;
+		cout << "error opening " << iname << "(" << fEffArea->GetListOfFiles()->GetEntries() << ")" << endl;
 		return false;
 	}
 	
-	fEffArea = new CEffArea( f );
 	cout << "reading effective areas from " << iname << endl;
-	cout << "total number of effective areas: " << f->GetEntries() << endl;
+	cout << "total number of effective areas: " << fEffArea->GetEntries() << endl;
+	
+	fEffArea->SetBranchAddress( "ze", &fze );
+	fEffArea->SetBranchAddress( "az", &fAzBin );
+	fEffArea->SetBranchAddress( "azMin", &fAzMin );
+	fEffArea->SetBranchAddress( "azMax", &fAzMax );
+	fEffArea->SetBranchAddress( "Woff", &fWoff );
+	fEffArea->SetBranchAddress( "noise", &fTNoise );
+	fEffArea->SetBranchAddress( "pedvar", &fTPedvar );
+	nbins = 0;
+	fEffArea->SetBranchAddress( "nbins", &nbins );
+	fEffArea->SetBranchAddress( "e0", e0 );
+	fEffArea->SetBranchAddress( "eff", eff );
+	nbins_esys = 0;
+	fEffArea->SetBranchAddress( "nbins_esys", &nbins_esys );
+	fEffArea->SetBranchAddress( "e0_esys", e0_esys );
+	fEffArea->SetBranchAddress( "esys_rel", esys_rel );
 	
 	return true;
 }
@@ -196,13 +211,9 @@ bool VEnergyThreshold::calculateEnergyThreshold( bool bFit, int nentries )
 		}
 	}
 	
-	if( nentries < 0 )
+	if( nentries < 0 ||  nentries > fEffArea->GetEntries() )
 	{
-		nentries = fEffArea->fChain->GetEntries();
-	}
-	if( nentries > fEffArea->fChain->GetEntries() )
-	{
-		nentries = fEffArea->fChain->GetEntries();
+		nentries = fEffArea->GetEntries();
 	}
 	for( int i = 0; i < nentries; i++ )
 	{
@@ -228,63 +239,56 @@ bool VEnergyThreshold::calculateEnergyThreshold( bool bFit, int nentries )
 		feff_500GeV = 0.;
 		feff_1TeV = 0.;
 		
-		copyEntry();
-		
-		TH1D* hLin = fEffArea->hEcut500;
-		if( hLin )
+		if( nbins > 1 )
 		{
-			feth = getEnergyThreshold( hLin, true, bFit );
-		}
-		else
-		{
-			if( fEffArea->nbins > 1 )
+			double idE = e0[1] - e0[0];
+			TH1D hLin( "hLin", "", nbins,
+					   e0[0] - idE,
+					   e0[nbins - 1] + idE );
+			for( int b = 0; b < nbins; b++ )
 			{
-				double idE = fEffArea->e0[1] - fEffArea->e0[0];
-				TH1D hLin( "hLin", "", fEffArea->nbins,
-						   fEffArea->e0[0] - idE,
-						   fEffArea->e0[fEffArea->nbins - 1] + idE );
-				for( int b = 0; b < fEffArea->nbins; b++ )
+				hLin.SetBinContent( b + 1, e0[b],
+									eff[b] *
+									TMath::Power( TMath::Power( 10., e0[b] ),
+												  -1.*2.4 ) );
+			}
+			feth = getEnergyThreshold( &hLin, true, bFit );
+		}
+		
+		if( nbins_esys > 1 )
+		{
+			vector< double > x;
+			vector< double > y;
+			for( int b = 0; b < nbins_esys; b++ )
+			{
+				if( TMath::Abs( esys_rel[b] ) > 1.e-3 )
 				{
-					hLin.SetBinContent( b + 1, fEffArea->e0[b],
-										fEffArea->eff[b] *
-										TMath::Power( TMath::Power( 10., fEffArea->e0[b] ),
-													  -1.*fEffArea->index ) );
+					x.push_back( e0_esys[b] );
+					y.push_back( esys_rel[b] );
 				}
-				feth = getEnergyThreshold( &hLin, true, bFit );
 			}
+			fesys_10p = getEnergy_maxSystematic( x, y, 0.10 );
+			fesys_15p = getEnergy_maxSystematic( x, y, 0.15 );
+			fesys_20p = getEnergy_maxSystematic( x, y, 0.20 );
 		}
+		TGraph* gEffAreaRec = new TGraph( 1 );
+		for( int b = 0; b < nbins; b++ )
+		{
+			gEffAreaRec->SetPoint( b, e0[b], eff[b] );
+		}
+		feff_300GeV = gEffAreaRec->Eval( log10( 0.3 ) );
+		feff_500GeV = gEffAreaRec->Eval( log10( 0.5 ) );
+		feff_1TeV = gEffAreaRec->Eval( log10( 1. ) );
+		feffFract_05p = getEnergy_MaxEffectiveAreaFraction( gEffAreaRec, 0.05 );
+		feffFract_10p = getEnergy_MaxEffectiveAreaFraction( gEffAreaRec, 0.10 );
+		feffFract_20p = getEnergy_MaxEffectiveAreaFraction( gEffAreaRec, 0.20 );
+		feffFract_50p = getEnergy_MaxEffectiveAreaFraction( gEffAreaRec, 0.50 );
+		feffFract_90p = getEnergy_MaxEffectiveAreaFraction( gEffAreaRec, 0.90 );
+		delete gEffAreaRec;
 		
-		TProfile* hSys = fEffArea->hEsysMCRelative;
-		if( hSys )
+		if( TMath::Abs( fAzMax - 1000. ) < 1.e-3 )
 		{
-			fesys_10p = getEnergy_maxSystematic( hSys, 0.10 );
-			fesys_15p = getEnergy_maxSystematic( hSys, 0.15 );
-			fesys_20p = getEnergy_maxSystematic( hSys, 0.20 );
-		}
-		TGraph* hG = fEffArea->gEffAreaRec;
-		if( !hG )
-		{
-			hG = new TGraph( 1 );
-			for( int b = 0; b < fEffArea->nbins; b++ )
-			{
-				hG->SetPoint( b, fEffArea->e0[b], fEffArea->eff[b] );
-			}
-			feff_300GeV = hG->Eval( log10( 0.3 ) );
-			feff_500GeV = hG->Eval( log10( 0.5 ) );
-			feff_1TeV = hG->Eval( log10( 1. ) );
-		}
-		if( hG )
-		{
-			feffFract_05p = getEnergy_MaxEffectiveAreaFraction( hG, 0.05 );
-			feffFract_10p = getEnergy_MaxEffectiveAreaFraction( hG, 0.10 );
-			feffFract_20p = getEnergy_MaxEffectiveAreaFraction( hG, 0.20 );
-			feffFract_50p = getEnergy_MaxEffectiveAreaFraction( hG, 0.50 );
-			feffFract_90p = getEnergy_MaxEffectiveAreaFraction( hG, 0.90 );
-			delete hG;
-		}
-		if( TMath::Abs( fEffArea->index - 2.4 ) < 1.e-3 && TMath::Abs( fEffArea->azMax - 1000. ) < 1.e-3 )
-		{
-			cout << "Threshold for index " << fEffArea->index << ": ";
+			cout << "Threshold : ";
 			cout << feth << " TeV, 10\% sys: " << fesys_10p << endl;
 		}
 		fTreeEth->Fill();
@@ -292,45 +296,34 @@ bool VEnergyThreshold::calculateEnergyThreshold( bool bFit, int nentries )
 	return true;
 }
 
-
-/*!
-    calculate lower energy threshold from systematics:
-    (interpolate between two closest values)
-*/
-double VEnergyThreshold::getEnergy_maxSystematic( TObject* h, double iSys )
+double VEnergyThreshold::getEnergy_maxSystematic( TGraphErrors* g, double iSys )
 {
-	if( !h )
+	if( !g )
 	{
 		return 0.;
 	}
 	vector< double > x;
 	vector< double > y;
-	
-	if( strcmp( "TProfile", h->ClassName() ) == 0 )
+	double e = 0.;
+	double s = 0.;
+	for( int b = 0; b < g->GetN(); b++ )
 	{
-		TProfile* p = ( TProfile* )h;
-		for( int i = 1; i < p->GetNbinsX(); i++ )
+		g->GetPoint( b, e, s );
+		if( TMath::Abs( s ) > 1.e-3 )
 		{
-			if( p->GetBinError( i ) < 0.001 )
-			{
-				continue;
-			}
-			x.push_back( p->GetBinCenter( i ) );
-			y.push_back( p->GetBinContent( i ) );
+			x.push_back( e );
+			y.push_back( s );
 		}
 	}
-	else if( strcmp( "TGraphErrors", h->ClassName() ) == 0 )
-	{
-		double a, b;
-		TGraphErrors* g = ( TGraphErrors* )h;
-		for( int i = 0; i < g->GetN(); i++ )
-		{
-			g->GetPoint( i, a, b );
-			x.push_back( a );
-			y.push_back( b );
-		}
-	}
-	
+	return getEnergy_maxSystematic( x, y, iSys );
+}
+
+/*!
+    calculate lower energy threshold from systematics:
+    (interpolate between two closest values)
+*/
+double VEnergyThreshold::getEnergy_maxSystematic( vector< double > x, vector< double > y, double iSys )
+{
 	double x1, x2, y1, y2, a, b;
 	
 	for( unsigned int i = 0; i < x.size(); i++ )
@@ -425,22 +418,6 @@ double VEnergyThreshold::getEnergyThreshold( TH1D* h, bool bLogEnergyAxis, bool 
 }
 
 
-void VEnergyThreshold::copyEntry()
-{
-	fze = fEffArea->ze;
-	fAzBin = fEffArea->az;
-	fAzMin  = fEffArea->azMin;
-	fAzMax = fEffArea->azMax;
-	fXoff = fEffArea->Xoff;
-	fYoff = fEffArea->Yoff;
-	fWoff = fEffArea->Woff;
-	fTNoise = fEffArea->noise;
-	fTNoisePE = fEffArea->noisePE;
-	fTPedvar = fEffArea->pedvar;
-	fSpectralIndex = fEffArea->index;
-}
-
-
 bool VEnergyThreshold::setUpThresholdTree()
 {
 	if( fDebug )
@@ -466,29 +443,25 @@ bool VEnergyThreshold::setUpThresholdTree()
 	fOutFile->cd();
 	
 	fTreeEth = new TTree( "fTreeEth", "thresholds in energy reconstruction" );
-	fTreeEth->Branch( "ze", &fze, "ze/D" );
-	fTreeEth->Branch( "az", &fAzBin, "az/I" );
-	fTreeEth->Branch( "azMin", &fAzMin, "azMin/D" );
-	fTreeEth->Branch( "azMax", &fAzMax, "azMax/D" );
-	fTreeEth->Branch( "Xoff", &fXoff, "Xoff/D" );
-	fTreeEth->Branch( "Yoff", &fYoff, "Yoff/D" );
-	fTreeEth->Branch( "Woff", &fWoff, "Woff/D" );
-	fTreeEth->Branch( "noise", &fTNoise, "noise/I" );
-	fTreeEth->Branch( "noisePE", &fTNoisePE, "noisePE/D" );
-	fTreeEth->Branch( "pedvar", &fTPedvar, "pedvar/D" );
-	fTreeEth->Branch( "index", &fSpectralIndex, "index/D" );
-	fTreeEth->Branch( "E_diffmax", &feth, "E_diffmax/D" );
-	fTreeEth->Branch( "E_sys10p", &fesys_10p, "E_sys10p/D" );
-	fTreeEth->Branch( "E_sys15p", &fesys_15p, "E_sys15p/D" );
-	fTreeEth->Branch( "E_sys20p", &fesys_20p, "E_sys20p/D" );
-	fTreeEth->Branch( "E_effFract_05p", &feffFract_05p, "E_effFract_05p/D" );
-	fTreeEth->Branch( "E_effFract_10p", &feffFract_10p, "E_effFract_10p/D" );
-	fTreeEth->Branch( "E_effFract_20p", &feffFract_20p, "E_effFract_20p/D" );
-	fTreeEth->Branch( "E_effFract_50p", &feffFract_50p, "E_effFract_50p/D" );
-	fTreeEth->Branch( "E_effFract_90p", &feffFract_90p, "E_effFract_90p/D" );
-	fTreeEth->Branch( "EffArea_300GeV", &feff_300GeV, "EffArea_300GeV/D" );
-	fTreeEth->Branch( "EffArea_500GeV", &feff_500GeV, "EffArea_500GeV/D" );
-	fTreeEth->Branch( "EffArea_1TeV", &feff_1TeV, "EffArea_1TeV/D" );
+	fTreeEth->Branch( "ze", &fze, "ze/F" );
+	fTreeEth->Branch( "az", &fAzBin, "az/s" );
+	fTreeEth->Branch( "azMin", &fAzMin, "azMin/F" );
+	fTreeEth->Branch( "azMax", &fAzMax, "azMax/F" );
+	fTreeEth->Branch( "Woff", &fWoff, "Woff/F" );
+	fTreeEth->Branch( "noise", &fTNoise, "noise/s" );
+	fTreeEth->Branch( "pedvar", &fTPedvar, "pedvar/F" );
+	fTreeEth->Branch( "E_diffmax", &feth, "E_diffmax/F" );
+	fTreeEth->Branch( "E_sys10p", &fesys_10p, "E_sys10p/F" );
+	fTreeEth->Branch( "E_sys15p", &fesys_15p, "E_sys15p/F" );
+	fTreeEth->Branch( "E_sys20p", &fesys_20p, "E_sys20p/F" );
+	fTreeEth->Branch( "E_effFract_05p", &feffFract_05p, "E_effFract_05p/F" );
+	fTreeEth->Branch( "E_effFract_10p", &feffFract_10p, "E_effFract_10p/F" );
+	fTreeEth->Branch( "E_effFract_20p", &feffFract_20p, "E_effFract_20p/F" );
+	fTreeEth->Branch( "E_effFract_50p", &feffFract_50p, "E_effFract_50p/F" );
+	fTreeEth->Branch( "E_effFract_90p", &feffFract_90p, "E_effFract_90p/F" );
+	fTreeEth->Branch( "EffArea_300GeV", &feff_300GeV, "EffArea_300GeV/F" );
+	fTreeEth->Branch( "EffArea_500GeV", &feff_500GeV, "EffArea_500GeV/F" );
+	fTreeEth->Branch( "EffArea_1TeV", &feff_1TeV, "EffArea_1TeV/F" );
 	
 	return true;
 }
@@ -589,7 +562,7 @@ double VEnergyThreshold::interpolateEnergyThreshold( VRunList* iRunData )
 }
 
 
-void VEnergyThreshold::plot_energyThresholds( string var, double ze, double woff, int noise, double index, int az, bool bPlot, string plot_option )
+void VEnergyThreshold::plot_energyThresholds( string var, double ze, double woff, int noise, int az, bool bPlot, string plot_option )
 {
 	if( !fTreeEth )
 	{
@@ -612,44 +585,36 @@ void VEnergyThreshold::plot_energyThresholds( string var, double ze, double woff
 	vector< string > iName;
 	vector< string > iTitle;
 	
-	// energy threshold vs spectral index
-	iName.push_back( "spectral index" );
-	iDraw.push_back( var + "*1.e3:index" );
-	sprintf( hname, "az == %d && noise == %d && TMath::Abs( ze - %f ) < 0.1 && TMath::Abs( Woff - %f ) < 0.05", az, noise, ze, woff );
-	iCut.push_back( hname );
-	sprintf( hname, "ze=%d deg, woff = %.2f deg, noise level = %d", ( int )ze, woff, noise );
-	iTitle.push_back( hname );
-	
 	// energy threshold vs zenith angle
 	iName.push_back( "zenith angle [deg]" );
 	iDraw.push_back( var + "*1.e3:ze" );
-	sprintf( hname, "az == %d && noise == %d && TMath::Abs( index - %f ) < 0.1 && TMath::Abs( Woff - %f ) < 0.05", az, noise, index, woff );
+	sprintf( hname, "az == %d && noise == %d && TMath::Abs( Woff - %f ) < 0.05", az, noise, woff );
 	iCut.push_back( hname );
-	sprintf( hname, "woff = %.2f deg, noise level = %d, spectral index = %.1f", woff, noise, index );
+	sprintf( hname, "woff = %.2f deg, noise level = %d", woff, noise );
 	iTitle.push_back( hname );
 	
 	// energy threshold vs wobble offsets
 	iName.push_back( "wobble offset [deg]" );
 	iDraw.push_back( var + "*1.e3:Woff" );
-	sprintf( hname, "az == %d && noise == %d && TMath::Abs( index - %f ) < 0.1 && TMath::Abs( ze - %f ) < 0.05", az, noise, index, ze );
+	sprintf( hname, "az == %d && noise == %d && TMath::Abs( ze - %f ) < 0.05", az, noise, ze );
 	iCut.push_back( hname );
-	sprintf( hname, "ze=%d deg, noise level = %d, spectral index = %.1f", ( int )ze, noise, index );
+	sprintf( hname, "ze=%d deg, noise level = %d", ( int )ze, noise );
 	iTitle.push_back( hname );
 	
 	// energy threshold vs pedestal variations
 	iName.push_back( "pedestal variation" );
 	iDraw.push_back( var + "*1.e3:pedvar" );
-	sprintf( hname, "az == %d && TMath::Abs( Woff - %f ) < 0.05 && TMath::Abs( index - %f ) < 0.1 && TMath::Abs( ze - %f ) < 0.05", az, woff, index, ze );
+	sprintf( hname, "az == %d && TMath::Abs( Woff - %f ) < 0.05 && TMath::Abs( ze - %f ) < 0.05", az, woff, ze );
 	iCut.push_back( hname );
-	sprintf( hname, "ze=%d deg, woff = %.2f deg, spectral index = %.1f", ( int )ze, woff, index );
+	sprintf( hname, "ze=%d deg, woff = %.2f deg", ( int )ze, woff );
 	iTitle.push_back( hname );
 	
 	// energy threshold vs azimuth angle
 	iName.push_back( "azimuth angle [deg]" );
 	iDraw.push_back( var + "*1.e3:azMin+30." );
-	sprintf( hname, "az != 16 && noise == %d && TMath::Abs( Woff - %f ) < 0.05 && TMath::Abs( index - %f ) < 0.1 && TMath::Abs( ze - %f ) < 0.05", noise, woff, index, ze );
+	sprintf( hname, "az != 16 && noise == %d && TMath::Abs( Woff - %f ) < 0.05 && TMath::Abs( ze - %f ) < 0.05", noise, woff, ze );
 	iCut.push_back( hname );
-	sprintf( hname, "ze=%d deg, woff = %.2f deg, noise level = %d, spectral index = %.1f", ( int )ze, woff, noise, index );
+	sprintf( hname, "ze=%d deg, woff = %.2f deg, noise level = %d", ( int )ze, woff, noise );
 	iTitle.push_back( hname );
 	
 	TCanvas* c = 0;

--- a/src/VEventLoop.cpp
+++ b/src/VEventLoop.cpp
@@ -274,12 +274,16 @@ bool VEventLoop::initEventLoop( string iFileName )
 				unsigned int i_counter = 0;
 				for( ;; )
 				{
-					i_tempReader.getNextEvent();
+					if( !i_tempReader.getNextEvent() )
+					{
+						break;
+					}
 					for( unsigned int i = 0; i < fRunPar->fTelToAnalyze.size(); i++ )
 					{
 						i_tempReader.setTelescopeID( fRunPar->fTelToAnalyze[i] );
 						// set number of samples
-						if( i_tempReader.getNumSamples() > 4 )
+						// (require at least 10 samples for any reasonable analysis)
+						if( i_tempReader.getNumSamples() > 9 )
 						{
 							setNSamples( fRunPar->fTelToAnalyze[i], i_tempReader.getNumSamples() );
 							i_nSampleSet[i] = true;
@@ -318,22 +322,18 @@ bool VEventLoop::initEventLoop( string iFileName )
 						}
 					}
 					i_counter++;
-					if( i_counter == 1000 )
+					if( i_counter == 10000 )
 					{
-						cout << "VEventLoop warning: could not find number of samples in the first 1000 events";
+						cout << "VEventLoop warning: could not find number of samples in the first 10000 events";
 						cout << " (this is normal for runs with event losses at the beginning)" << endl;
 					}
-					if( i_counter > 999999 )
-					{
-						cout << "VEventLoop warning: could not find number of samples in the first 999999 events" << endl;
-						break;
-					}
 				}
-				if( getNSamples() == 0 || i_counter > 99999 )
+				// if( getNSamples() == 0 || i_counter > 9999998 )
+				if( getNSamples() == 0 )
 				{
 					cout << "VEventLoop::initEventLoop error: could not find any telescope events to determine sample length" << endl;
 					cout << "exiting..." << endl;
-					exit( -1 );
+					exit( EXIT_FAILURE );
 				}
 				cout << "Found consistent number of samples in vbf file after " << i_counter + 1 << " event(s): ";
 				for( unsigned int i = 0; i < fRunPar->fTelToAnalyze.size(); i++ )

--- a/src/VImageBaseAnalyzer.cpp
+++ b/src/VImageBaseAnalyzer.cpp
@@ -863,17 +863,6 @@ void VImageBaseAnalyzer::findDeadChans( bool iLowGain, bool iFirst )
 	}
 	
 	// reset dead channel vector
-	/*
-	// this is duplicated code, simplify
-	if( fRunPar->fMCNdead && iFirst )
-	{
-		setDead( false, iLowGain );
-	}
-	else
-	{
-		setDead( false, iLowGain );
-	}
-	*/
 	setDead( false, iLowGain );
 	
 	// get mean and rms of pedvar

--- a/src/VTMVAEvaluator.cpp
+++ b/src/VTMVAEvaluator.cpp
@@ -223,28 +223,23 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
 				{
 					iEnergyData = ( VTMVARunDataEnergyCut* )iF.Get( "fDataEnergyCut" );
 					iZenithData = ( VTMVARunDataZenithCut* )iF.Get( "fDataZenithCut" );
-					if( !iEnergyData )
+					if( !iEnergyData || !iZenithData )
 					{
-						cout << "No energy cut data: setting goodrun to false" << endl;
-						bGoodRun = false;
-					}
-					// backwards compatibility
-					if( !iZenithData )
-					{
-						cout << "No zenith cut data: ";
-						cout << " setting goodrun to false" << endl;
+						cout << "  No energy or zenith cut data" << endl;
 						bGoodRun = false;
 					}
 					// signal efficiency
-					sprintf( hname, "Method_%s/%s_0/MVA_%s_0_effS", fTMVAMethodName.c_str(), fTMVAMethodName.c_str(), fTMVAMethodName.c_str() );
-					
+					sprintf( hname, "Method_%s/%s_0/MVA_%s_0_effS",
+							 fTMVAMethodName.c_str(), fTMVAMethodName.c_str(), fTMVAMethodName.c_str() );
+							 
 					if( !iF.Get( hname ) )
 					{
-						cout << "No signal efficiency histogram found (" << hname << ")" << endl;
+						cout << "  No signal efficiency histogram found (" << hname << ")" << endl;
 						bGoodRun = false;
 					}
 				}
-				// allow that first files are missing (this happens when there are no training events in the first energy bins)
+				// allow that first files are missing
+				// (this happens when there are no training events in the first energy or zenith bins)
 				if( !bGoodRun )
 				{
 					if( i == iMinMissingBin || j == jMinMissingBin )
@@ -255,30 +250,27 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
 						if( i == iMinMissingBin )
 						{
 							cout << "  assume this is a low-energy empty bin (bin number " << i << ";";
-							cout << " number of missing bins: " << iMinMissingBin + 1 << ")" << endl;
+							cout << " number of missing energy bins: " << iMinMissingBin + 1 << ")" << endl;
 							iMinMissingBin++;
 						}
 						if( j == jMinMissingBin )
 						{
 							cout << "  assume this is a zenith empty bin (bin number " << j << ";";
-							cout << " number of missing bins: " << jMinMissingBin + 1 << ")" << endl;
+							cout << " number of missing zenith bins: " << jMinMissingBin + 1 << ")" << endl;
+							jMinMissingBin++;
 						}
 						continue;
 					}
 					else if( i == ( iWeightFileIndex_Emax ) || j == ( iWeightFileIndex_Zmax ) )
 					{
-						cout << "VTMVAEvaluator::initializeWeightFiles() warning: TMVA root file not found " << iFullFileName << endl;
+						cout << "VTMVAEvaluator::initializeWeightFiles(): TMVA root file not found " << iFullFileName << endl;
 						if( i == ( iWeightFileIndex_Emax ) )
 						{
 							cout << "  assume this is a high-energy empty bin (bin number " << i << ")" << endl;
-							iNbinE--;
-							iWeightFileIndex_Emax--;
 						}
 						if( j == ( iWeightFileIndex_Zmax ) )
 						{
 							cout << "  assume this is a high-zenith empty bin (bin number " << j << ")" << endl;
-							iNbinZ--;
-							iWeightFileIndex_Zmax--;
 						}
 						continue;
 					}
@@ -352,15 +344,7 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
 				
 				sprintf( hname, "%d%d", i, j );
 				fTMVAData.back()->fTMVAMethodTag = hname;
-				if( iNbinZ > 1 )
-				{
-					sprintf( hname, "%d_%d", i, j );
-				}
-				else
-				{
-					sprintf( hname, "%d", i );
-				}
-				
+				sprintf( hname, "%d_%d", i, j );
 				fTMVAData.back()->fTMVAMethodTag_2 = hname;
 				fTMVAData.back()->fTMVAName = iTMVAName;
 				fTMVAData.back()->fTMVAFileName = iFullFileName;


### PR DESCRIPTION
Changes compared to alpha.19:

- critical bug fix for application of BDT gamma/hadron separation: highest zenith bins was completely dropped in case training files are missing for one energy bin. This affected the hard cuts only and removed all events for the lowest elevation bin (TMVA evaluator)
- code cleanup in TMVA evaluator
- increased robustness for reading number of samples of readout window from VBF files. This recovers those runs, where for some reason the more than 10,000 events in the beginning of the run are empty, but the rest of the run is ok.
- adapted energy threshold calculation to optimised effective area tree structures
