### PR TITLE
v490 - alpha.21

### DIFF
--- a/docs/EVNDISP.commandline.md
+++ b/docs/EVNDISP.commandline.md
@@ -8,10 +8,15 @@ Typical use cases:
 ------------------
 
 Plot VTS data:
-./bin/evndisp -display=1 -runnumber=<run number>
+./bin/evndisp -display=1 -runnumber=<run number> \
+              -calibrationdirectory <point to directory with calibration values>
+              (for larger display, add the option -highres)
 
 Quick plotting of VTS data, ignoring all calibration data:
 ./bin/evndisp -plotraw -nocalibnoproblem -display=1 -sourcefile <your vbf data file>
+
+For analysis, use the ANALYSIS.evndisp.sh script. 
+To run the calibration steps only, use the ANALYSIS.evndisp.sh with calibration option set to 5.
 
 General:
 --------

--- a/inc/VCalibrator.h
+++ b/inc/VCalibrator.h
@@ -6,7 +6,7 @@
 #include "VImageBaseAnalyzer.h"
 #include "VPedestalCalculator.h"
 #include "VDB_CalibrationInfo.h"
-#include <VSQLTextFileReader.h>
+#include "VSQLTextFileReader.h"
 
 #include "TClonesArray.h"
 #include "TFile.h"

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -197,7 +197,7 @@ VEvndispRunParameter::VEvndispRunParameter( bool bSetGlobalParameter ) : VGlobal
 	ftraceamplitudecorrectionFile = "";
 	ftracefit = -1.;
 	ftracefitfunction = "ev";
-	freconstructionparameterfile = "EVNDISP.reconstruction.runparameter.v4x";
+	freconstructionparameterfile = "EVNDISP.reconstruction.runparameter.AP.v4x";
 	
 	////////////////////////////////////////////////////////////////////////////////
 	// pulse timing (fraction of maximum where times are determined)


### PR DESCRIPTION
Changes with respect to alpha.20:

- improved help for `evndisp`
- correct include settings in VCalibrator
- set `EVNDISP.reconstruction.runparameter.AP.v4x` as default run parameter file