### PR TITLE
bug fix in updating epoch string

### DIFF
--- a/src/VEnergySpectrum.cpp
+++ b/src/VEnergySpectrum.cpp
@@ -315,14 +315,16 @@ bool VEnergySpectrum::combineRuns( vector< int > runlist, bool bLinearX )
 		TH1D* i_hErecCountOff = ( TH1D* )getHistogram( hname, fRunList[i].runnumber, "energyHistograms", fOffsetDistance );
 		// histogram with systematic errors (same for on and off)
 		hname = "gMeanEnergySystematicError";
-		TGraphErrors* i_hEsys = ( TGraphErrors* )getHistogram( hname, fRunList[i].runnumber, "EffectiveAreas", fOffsetDistance );
+		TGraphErrors* i_hEsys = ( TGraphErrors* )getHistogram(
+									hname, fRunList[i].runnumber, "EffectiveAreas", fOffsetDistance );
 		if( fAnalysisEnergyThresholdDefinition == 1 && !i_hEsys )
 		{
 			cout << "WARNING: histogram with systematic error in energy reconstruction not found";
 			cout << " (run " << fRunList[i].runnumber << ")" << endl;
 		}
 		// get effective area
-		TH1* i_hEffAreaP = ( TH1* )getHistogram( "herecEffectiveArea_on", fRunList[i].runnumber, "energyHistograms", fOffsetDistance );
+		TH1* i_hEffAreaP = ( TH1* )getHistogram(
+							   "herecEffectiveArea_on", fRunList[i].runnumber, "energyHistograms", fOffsetDistance );
 		TGraphErrors* i_gEff = new TGraphErrors( 0 );
 		VHistogramUtilities i_hisUtl;
 		i_hisUtl.get_Graph_from_Histogram( i_hEffAreaP, i_gEff );
@@ -334,23 +336,9 @@ bool VEnergySpectrum::combineRuns( vector< int > runlist, bool bLinearX )
 			i_gEff = ( TGraphErrors* )getHistogram( hname, fRunList[i].runnumber, "EffectiveAreas", fOffsetDistance );
 			if( !i_gEff )
 			{
-				// third choice for backwards compatibility to v35x version
-				hname = "gMeanEffectiveAreaErec";
-				i_gEff = ( TGraphErrors* )getHistogram( hname, fRunList[i].runnumber, "EffectiveAreas", fOffsetDistance );
-				// fourth choice for backwards compatibility to v35x version
-				if( !i_gEff )
-				{
-					hname = "gMeanEffectiveAreaErec_off";
-					i_gEff = ( TGraphErrors* )getHistogram( hname, fRunList[i].runnumber, "EffectiveAreas", fOffsetDistance );
-					if( !i_gEff )
-					{
-						cout << "WARNING: no mean effective area graph found, ignoring run ";
-						cout << " (run " << fRunList[i].runnumber << ")" << endl;
-						continue;
-					}
-				}
-				cout << "WARNING: effective areas not found as expected; reading apparently v35X file" << endl;
-				cout << "\t --- this version is not completely backwards compatible to v35X --- " << endl;
+				cout << "WARNING: no mean effective area graph found, ignoring run ";
+				cout << " (run " << fRunList[i].runnumber << ")" << endl;
+				continue;
 			}
 		}
 		
@@ -367,19 +355,25 @@ bool VEnergySpectrum::combineRuns( vector< int > runlist, bool bLinearX )
 		// get energy threshold (may depend on ze, az, ...)
 		// (for energy threshold definitions see VEnergyThreshold )
 		/////////////////////////////////////////////////////
-		if( fAnalysisEnergyThresholdDefinition == 0 )            // no energy threshold
+		// no energy threshold
+		if( fAnalysisEnergyThresholdDefinition == 0 )
 		{
 			fRunList[i].energyThreshold = 0.;
 		}
-		else if( fAnalysisEnergyThresholdDefinition == 1 )       // energy threshold: systematic smaller then given value
+		// energy threshold: systematic smaller then given value
+		else if( fAnalysisEnergyThresholdDefinition == 1 )
 		{
-			fRunList[i].energyThreshold = iEnergyThresholdCalculator.getEnergy_maxSystematic( i_hEsys, fAnalysisMaxEnergySystematic );
+			fRunList[i].energyThreshold = iEnergyThresholdCalculator.getEnergy_maxSystematic(
+											  i_hEsys, fAnalysisMaxEnergySystematic );
 		}
-		else if( fAnalysisEnergyThresholdDefinition == 2 )       // energy threshold: effective area > given fraction of maximum effective area (typical value is 10%)
+		// energy threshold: effective area > given fraction of maximum effective area (typical value is 10%)
+		else if( fAnalysisEnergyThresholdDefinition == 2 )
 		{
-			fRunList[i].energyThreshold = iEnergyThresholdCalculator.getEnergy_MaxEffectiveAreaFraction( i_gEff, fAnalysisMaxEffectiveAreaFraction );
+			fRunList[i].energyThreshold = iEnergyThresholdCalculator.getEnergy_MaxEffectiveAreaFraction(
+											  i_gEff, fAnalysisMaxEffectiveAreaFraction );
 		}
-		else if( fAnalysisEnergyThresholdDefinition == 3 )       // energy threshold given by fixed value (e.g. 0.5 TeV)
+		// energy threshold given by fixed value (e.g. 0.5 TeV)
+		else if( fAnalysisEnergyThresholdDefinition == 3 )
 		{
 			fRunList[i].energyThreshold = iEnergyThresholdCalculator.getEnergy_fixedValue();
 		}

--- a/src/VEvndispRunParameter.cpp
+++ b/src/VEvndispRunParameter.cpp
@@ -929,7 +929,7 @@ string VEvndispRunParameter::getInstrumentEpoch( bool iMajor, bool iUpdateInstru
 	// re-read instrument epoch
 	if( iUpdateInstrumentEpoch )
 	{
-		updateInstrumentEpochFromFile();
+		updateInstrumentEpochFromFile( "usedefault", "EPOCH" );
 	}
 	if( iMajor )
 	{

--- a/src/VFluxCalculation.cpp
+++ b/src/VFluxCalculation.cpp
@@ -546,19 +546,10 @@ void VFluxCalculation::getIntegralEffectiveArea()
 				g = ( TGraphAsymmErrors* )gDirectory->Get( "gMeanEffectiveArea_off" );
 				if( !g )
 				{
-					// backwards compatibility to files prodcued with v35x
-					g = ( TGraphAsymmErrors* )gDirectory->Get( "gMeanEffectiveAreaEMC" );
-					if( !g )
-					{
-						g = ( TGraphAsymmErrors* )gDirectory->Get( "gMeanEffectiveAreaEMC_off" );
-					}
-					if( !g )
-					{
-						cout << "error: effective area graph not found" << endl;
-						cout << "continue..." << endl;
-						fRunEffArea[i] = 0.;
-						continue;
-					}
+					cout << "error: effective area graph not found" << endl;
+					cout << "continue..." << endl;
+					fRunEffArea[i] = 0.;
+					continue;
 				}
 			}
 			

--- a/src/makeRadialAcceptance.cpp
+++ b/src/makeRadialAcceptance.cpp
@@ -193,7 +193,7 @@ int main( int argc, char* argv[] )
 			ifile << "/" << fRunPara->fRunList[i].fRunOff << ".mscw.root";
 			if( ! check_if_file_exists( ifile.str() ) )
 			{
-				cout << "error: file not found, " << ifile << endl;
+				cout << "error: file not found, " << ifile.str() << endl;
 				exit( EXIT_FAILURE );
 			}
 		}

--- a/src/makeRadialAcceptance.cpp
+++ b/src/makeRadialAcceptance.cpp
@@ -55,22 +55,29 @@ int main( int argc, char* argv[] )
 		string fCommandLine = argv[1];
 		if( fCommandLine == "-v" || fCommandLine == "--version" )
 		{
-			VGlobalRunParameter iRunPara;
-			cout << iRunPara.getEVNDISP_VERSION() << endl;
+			VGlobalRunParameter fRunPara;
+			cout << fRunPara.getEVNDISP_VERSION() << endl;
 			exit( EXIT_SUCCESS );
 		}
 	}
 	
+	///////////////////////////////////////////
+	// use VAnaSumRunParameter to read run lists and list of
+	// exclusion regions
 	VAnaSumRunParameter* fRunPara = new VAnaSumRunParameter();
 	
+	///////////////////////////////////////////
+	// print general stuff and version numbers
 	cout << endl;
-	cout << "makeRadialAcceptance " << fRunPara->getEVNDISP_VERSION() << endl << endl;
+	cout << "makeRadialAcceptance (" << fRunPara->getEVNDISP_VERSION() << ")" << endl << endl;
 	cout << "determine radial acceptance from off events (after cuts)" << endl;
 	cout << endl;
 	
+	///////////////////////////////////////////
 	// read options from command line
 	parseOptions( argc, argv );
 	
+	///////////////////////////////////////////
 	//find telescopes to analyse
 	for( unsigned int i = 0; i < teltoanastring.length(); i++ )
 	{
@@ -78,6 +85,7 @@ int main( int argc, char* argv[] )
 		teltoana.push_back( atoi( i_tel.c_str() ) - 1 );
 	}
 	
+	///////////////////////////////////////////
 	// read file list from run list file
 	if( listfilename.size() > 0 )
 	{
@@ -109,9 +117,9 @@ int main( int argc, char* argv[] )
 	if( fo->IsZombie() )
 	{
 		cout << "makeRadialAcceptances: error opening output file " << outfile << endl;
-		return 0;
+		exit( EXIT_FAILURE );
 	}
-	cout << endl << "writing acceptance curves to " << fo->GetName() << endl;
+	cout << endl << "open output file for acceptance curves: " << fo->GetName() << endl;
 	TDirectory* facc_dir = ( TDirectory* )fo;
 	
 	// create acceptance object
@@ -127,12 +135,13 @@ int main( int argc, char* argv[] )
 		}
 		else
 		{
-			cout << "Error, directory specified by makeRadialAcceptance -w option '" << histdir << "' does not exist, exiting..." << endl;
-			return 0;
+			cout << "Error, directory specified by makeRadialAcceptance -w option '";
+			cout << histdir << "' does not exist, exiting..." << endl;
+			exit( EXIT_FAILURE );
 		}
 	}
 	
-	// az dependent measurement
+	// az dependent radial acceptance curves
 	vector< VRadialAcceptance* > facc_az;
 	vector< string > fDirName;
 	vector< string > fDirTitle;
@@ -164,12 +173,15 @@ int main( int argc, char* argv[] )
 			facc_az_dir.back()->cd();
 			facc_az.push_back( new VRadialAcceptance( fCuts, fRunPara ) );
 			facc_az.back()->setAzCut( iAz_min[i], iAz_max[i] );
-			cout << "initializing AZ dependend radial acceptance class for ";
+			cout << "initializing azimuth dependend radial acceptance class for ";
 			cout << iAz_min[i] << " < az <= " <<   iAz_max[i] << endl;
 		}
 	}
 	
-	// loop over all files and fill acceptances
+	//////////////////////////////////////////////////////////////
+	// main loop over all runs
+	//   - fill radial acceptances per run
+	//   - fill average radial acceptance
 	for( unsigned int i = 0; i < fRunPara->fRunList.size(); i++ )
 	{
 		ostringstream ifile;
@@ -181,7 +193,7 @@ int main( int argc, char* argv[] )
 			ifile << "/" << fRunPara->fRunList[i].fRunOff << ".mscw.root";
 			if( ! check_if_file_exists( ifile.str() ) )
 			{
-				cout << "Error reading " << ifile.str() << endl;
+				cout << "error: file not found, " << ifile << endl;
 				exit( EXIT_FAILURE );
 			}
 		}
@@ -267,6 +279,7 @@ int main( int argc, char* argv[] )
 		{
 			d->GetEntry( n );
 			
+			// printout for MC
 			if( n == 0 and d->isMC() )
 			{
 				cout << "\t (analysing MC data)" << endl;
@@ -294,6 +307,7 @@ int main( int argc, char* argv[] )
 		fTest.Close();
 	}
 	
+	/////////////////////////////////////////
 	// write acceptance files to disk
 	
 	facc->calculate2DBinNormalizationConstant() ;
@@ -314,7 +328,9 @@ int main( int argc, char* argv[] )
 
 
 /*!
+
     read in command line parameters
+
 */
 int parseOptions( int argc, char* argv[] )
 {


### PR DESCRIPTION
Epochs where not updated correctly when using `printRunParameter` with the `-updated-runinfo` options. This affects running mscw analysis with updated `VERITAS.Epochs.runparameter` file.

(includes also changes to comments and printouts in `makeRadialAcceptances` and removal of obsolete code in Flux and Energyspectrum calculation)