### PR TITLE
In radial acceptance, skip runs with missing multiplicity

### DIFF
--- a/src/makeRadialAcceptance.cpp
+++ b/src/makeRadialAcceptance.cpp
@@ -236,8 +236,8 @@ int main( int argc, char* argv[] )
 				cout << teltoana[i] << "  ";
 			}
 			cout << endl;
-			cout << "\t" << teltoana.size() << "\t" << iParV2->fTelToAnalyze.size() << endl;
-			exit( EXIT_FAILURE );
+			cout << "Ignoring this file" << endl;
+			continue;
 		}
 		
 		// set gamma/hadron cuts


### PR DESCRIPTION
Until: makeRadialAcceptance stopped with error message; prefer now to skip the run (otherwise we have to put  work into getting 4-tel only run lists)