### PR TITLE
v490.9-dev2 - removal of size2

### DIFF
--- a/.github/workflows/ci-buildmatrix-cpp11.yml
+++ b/.github/workflows/ci-buildmatrix-cpp11.yml
@@ -44,4 +44,4 @@ jobs:
           export LD_LIBRARY_PATH="${EVNDISPSYS}/obj:${EVNDISPSYS}/lib:${LD_LIBRARY_PATH}"
           export LD_LIBRARY_PATH="${VBFSYS}/lib:${LD_LIBRARY_PATH}"
           export SOFASYS=/sofa
-          make VTS
+          make -j 4 VTS

--- a/.github/workflows/ci-buildmatrix-cpp11.yml
+++ b/.github/workflows/ci-buildmatrix-cpp11.yml
@@ -3,9 +3,8 @@ name: cpp11-buildmatrix
 
 # Controls when the workflow will run
 on:
-  #  pull_request:
-  #  branches: [main, master, v490-dev-v0.7]
-  # run this workflow manually from the Actions tab
+  pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:
@@ -20,8 +19,7 @@ jobs:
     container: ${{ matrix.root }}
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: vbf
         run: |

--- a/.github/workflows/ci-buildmatrix-cpp11.yml
+++ b/.github/workflows/ci-buildmatrix-cpp11.yml
@@ -3,8 +3,8 @@ name: cpp11-buildmatrix
 
 # Controls when the workflow will run
 on:
-  pull_request:
-    branches: [main, master]
+  #  pull_request:
+  #  branches: [main, master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-buildmatrix-cpp11.yml
+++ b/.github/workflows/ci-buildmatrix-cpp11.yml
@@ -14,7 +14,6 @@ jobs:
         os: [ubuntu-latest]
         root:
           - "rootproject/root:6.24.06-centos7"
-          - "rootproject/root:6.22.08-ubuntu20.04"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.root }}
 

--- a/.github/workflows/ci-buildmatrix-cpp17.yml
+++ b/.github/workflows/ci-buildmatrix-cpp17.yml
@@ -47,4 +47,4 @@ jobs:
           export LD_LIBRARY_PATH="${EVNDISPSYS}/obj:${EVNDISPSYS}/lib:${LD_LIBRARY_PATH}"
           export LD_LIBRARY_PATH="${VBFSYS}/lib:${LD_LIBRARY_PATH}"
           export SOFASYS=/sofa
-          make VTS
+          make -j 4 VTS

--- a/.github/workflows/ci-buildmatrix-cpp17.yml
+++ b/.github/workflows/ci-buildmatrix-cpp17.yml
@@ -4,8 +4,7 @@ name: cpp17-buildmatrix
 # Controls when the workflow will run
 on:
   pull_request:
-    branches: [main, master, v490-dev-v0.7]
-  # run this workflow manually from the Actions tab
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:
@@ -16,13 +15,16 @@ jobs:
         root:
           - "rootproject/root:latest"
           - "rootproject/root:6.26.06-ubuntu22.04"
-          - "rootproject/root:6.26.06-fedora35"
+          - "rootproject/root:6.30.02-alma9
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.root }}
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
+
+      - name: install libblas
+        if: ${{ matrix.root == 'rootproject/root:latest' || matrix.root == 'rootproject/root:6.26.06-ubuntu22.04' }}
+        run: apt-get install -y libblas-dev
 
       - name: vbf
         run: |

--- a/.github/workflows/ci-buildmatrix-cpp17.yml
+++ b/.github/workflows/ci-buildmatrix-cpp17.yml
@@ -15,7 +15,7 @@ jobs:
         root:
           - "rootproject/root:latest"
           - "rootproject/root:6.26.06-ubuntu22.04"
-          - "rootproject/root:6.30.02-alma9
+          - "rootproject/root:6.30.02-alma9"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.root }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install libblas
-        run: sudo apt-get install -y libblas-dev
+        run: apt-get install -y libblas-dev
 
       - name: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,11 @@ jobs:
     container: ${{ matrix.root }}
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
 
-      # Runs a set of commands using the runners shell
+      - name: install libblas
+        run: sudo apt-get install -y libblas-dev
+
       - name: build
         run: |
           root-config --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request
-  # events but only for the main branch
   pull_request:
     branches: [main, master]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
@@ -38,4 +34,4 @@ jobs:
           export SOFASYS=${EVNDISPSYS}/sofa
           ./install_sofa.sh CI
           make config
-          make VTS
+          make -j 4 VTS

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Eventdisplay is a C++ based library and designed to run in typical Linux environ
 
 CERN's [ROOT](https://root.cern.ch/) library for I/O, histogramming, and statistical applications:
 
-- ROOT versions >= 6.20
+- ROOT versions >= 6.28
 - the first-stage tool `evndisp` requires ROOT compiled with mysql for access to the VERITAS database. Pre-compiled version of ROOT (downloaded from [here](https://root.cern/install/)) have mysql installed. If building from source, ensure the mysql dependencies are installed and compiler flags are added (see [root installation page](https://root.cern/install/build_from_source/)). All other stages of Eventdisplay do not required mysql - meaning e.g., the conda-based installation of Eventdisplay is fine.
 - paths for ROOT should be set through e.g.,
 
@@ -28,7 +28,7 @@ root-config --has-mysql
 ### SOFA
 
 [SOFA](http://www.iausofa.org/current_C.html) for all astronometry transformations.
- 
+
 Download and install using this script in the $EVNDISPSYS directory:
 
 ```
@@ -63,7 +63,7 @@ Eventdisplay can be used efficiently with the correct environmental variables se
 
 ### Compiling and Linking
 
-ROOTSYS :   (required) ROOT installation; add $ROOTSYS/lib to $LD_LIBRARY_PATH and $ROOTSYS/bin to $PATH 
+ROOTSYS :   (required) ROOT installation; add $ROOTSYS/lib to $LD_LIBRARY_PATH and $ROOTSYS/bin to $PATH
 
 SOFASYS:    (required) Astronomy library from Sofa
 
@@ -83,11 +83,11 @@ EVNDISPSCRIPTS: Eventdisplay scripts directory
 
 Assume a computing environment, where several users are analysis the same raw data
 (would be in $VERITAS_DATA_DIR), but having their analysis results written to their own
-directories ($VERITAS_USER_DATA_DIR). 
+directories ($VERITAS_USER_DATA_DIR).
 Note that $VERITAS_DATA_DIR and $VERITAS_USER_DATA_DIR can point to the same directory.
 
 - VERITAS_EVNDISP_AUX_DIR:  directory with all auxiliary data like calibration files, lookup tables, effective areas, etc
-- VERITAS_DATA_DIR :        directory containing the raw telescope data or input simulation files 
+- VERITAS_DATA_DIR :        directory containing the raw telescope data or input simulation files
 - VERITAS_USER_DATA_DIR :   user data directory: containing output files from this analysis package
 - VERITAS_USER_LOG_DIR :    user log file directory: log files and temporary scripts are written to this directory
 
@@ -107,14 +107,14 @@ make config
 
 Compare the output with the requirements on software and environmental variable settings described above.
 
-In the main Eventdisplay directory ($EVNDISPSYS is pointing to this directory), compile all Eventdisplay binaries with 
+In the main Eventdisplay directory ($EVNDISPSYS is pointing to this directory), compile all Eventdisplay binaries with
 
 ```
-source ./setObservatory.sh VTS 
+source ./setObservatory.sh VTS
 make VTS
 ```
 
-If you are working on a computing with several cores, this can be accelerated by e.g. compiling with four cores in parallel: 
+If you are working on a computing with several cores, this can be accelerated by e.g. compiling with four cores in parallel:
 
 ```
 source ./setObservatory.sh VTS

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #
 #  Optional libraries:
 #
-#  for using GSL libraries (as part of ROO  mathmore)
+#  for using GSL libraries (as part of ROOT mathmore)
 #
 #  for using FITS (optional)
 #    FITSSYS (pointing to FITS installation)
@@ -540,7 +540,7 @@ printCrabSensitivity =		./obj/printCrabSensitivity.o \
 							./obj/VAnaSumRunParameter.o ./obj/VAnaSumRunParameter_Dict.o \
 							./obj/VTimeMask.o ./obj/VTimeMask_Dict.o \
 							./obj/CRunSummary.o ./obj/CRunSummary_Dict.o \
-					
+
 
 ./obj/printCrabSensitivity.o:	./src/printCrabSensitivity.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
@@ -555,7 +555,7 @@ printCrabSensitivity:	$(printCrabSensitivity)
 # logFile
 ########################################################
 LOGFILE =		./obj/logFile.o \
-					
+
 
 ./obj/logFile.o:	./src/logFile.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
@@ -725,7 +725,7 @@ ifneq ($(TSPECTRUMFLAG),-DNOSPECTRUM)
 endif
 
 ifeq ($(ASTRONMETRY),-DASTROSLALIB)
-  SHAREDOBJS += ./obj/VASlalib.o ./obj/VASlalib_Dict.o 
+  SHAREDOBJS += ./obj/VASlalib.o ./obj/VASlalib_Dict.o
 endif
 
 ifneq ($(GSLFLAG),-DNOGSL)
@@ -925,7 +925,7 @@ compareDatawithMC:	$(COMPAREDATAMCOBJ)
 	@echo "$@ done"
 
 ########################################################
-# printMJD 
+# printMJD
 ########################################################
 PRINTMJDOBJ=		./obj/VSkyCoordinatesUtilities.o \
 					./obj/VAstronometry.o \
@@ -940,7 +940,7 @@ printMJD:	$(PRINTMJDOBJ)
 	@echo "$@ done"
 
 ########################################################
-# printSQLDate 
+# printSQLDate
 ########################################################
 printSQLDateOBJ=		./obj/VSkyCoordinatesUtilities.o \
 					./obj/VAstronometry.o \
@@ -1532,7 +1532,7 @@ ifeq ($(GSLFLAG),-DNOGSL)
 	@echo "evndisp without GSL libraries (no Hough muon calibration, no likelihood fitter)"
 else
 	@echo "evndisp with GSL libraries (used in Hough muon calibration, likelihood fitter)"
-	@echo "   GSL  $(GSLFLAG)" 
+	@echo "   GSL  $(GSLFLAG)"
 	@echo "   $(GSLCFLAGS) $(GSLLIBS)"
 endif
 	@echo ""
@@ -1602,7 +1602,7 @@ else
 endif
 
 ###############################################################################################################################
-# source code formating
+# source code formatting
 ###############################################################################################################################
 formatSourceCode:
 	@echo ""

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -87,7 +87,6 @@ class CData
 		Float_t         meanPedvar_ImageT[VDST_MAXTELESCOPES];
 		Double_t        dist[VDST_MAXTELESCOPES];
 		Double_t        size[VDST_MAXTELESCOPES];
-		Double_t        size2[VDST_MAXTELESCOPES];
 		Double_t        fraclow[VDST_MAXTELESCOPES];
 		Double_t        loss[VDST_MAXTELESCOPES];
 		Double_t        max1[VDST_MAXTELESCOPES];
@@ -192,7 +191,6 @@ class CData
 		TBranch*        b_meanPedvar_ImageT;      //!
 		TBranch*        b_dist;                   //!
 		TBranch*        b_size;                   //!
-		TBranch*        b_size2;                  //!
 		TBranch*        b_fraclow;                //!
 		TBranch*        b_loss;                   //!
 		TBranch*        b_max1;                   //!
@@ -590,17 +588,6 @@ void CData::Init( TTree* tree )
 	{
 		fChain->SetBranchAddress( "dist", dist );
 		fChain->SetBranchAddress( "size", size );
-		if( fChain->GetBranchStatus( "size2" ) )
-		{
-			fChain->SetBranchAddress( "size2", size2 );
-		}
-		else
-		{
-			for( int i = 0; i < VDST_MAXTELESCOPES; i++ )
-			{
-				size2[i] = 0.;
-			}
-		}
 		if( fChain->GetBranchStatus( "fracLow" ) )
 		{
 			fChain->SetBranchAddress( "fracLow", fraclow );
@@ -687,7 +674,6 @@ void CData::Init( TTree* tree )
 		{
 			dist[i] = 0.;
 			size[i] = 0.;
-			size2[i] = 0.;
 			fraclow[i] = 0.;
 			loss[i] = 0.;
 			max1[i] = 0.;
@@ -916,7 +902,6 @@ Bool_t CData::Notify()
 
 	b_dist = fChain->GetBranch( "dist" );
 	b_size = fChain->GetBranch( "size" );
-	b_size2 = fChain->GetBranch( "size2" );
 	b_fraclow = fChain->GetBranch( "fraclow" );
 	b_max1 = fChain->GetBranch( "max1" );
 	b_max2 = fChain->GetBranch( "max2" );

--- a/inc/VDeadPixelOrganizer.h
+++ b/inc/VDeadPixelOrganizer.h
@@ -104,7 +104,10 @@ class VNGain
 		vector<VNStateDuration> stateHistory ;
 
 		// functions
-		VNGain() { fIsLow = false; } ;
+		VNGain()
+		{
+			fIsLow = false;
+		} ;
 		void initialize( string gainType, VNPixel* parentVNP ) ;
 		void updateState( int mjd, double time, PixelStateInt state ) ;
 		void setParentVNPixelPointer( VNPixel* ptr ) ;

--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -247,7 +247,7 @@ class VDispAnalyzer
 		void  setQualityCuts( unsigned int iNImages_min = 0, float iAxesAngles_min = 0.,
 							  float imaxdist = 1.e5, float imaxloss = 1.,
 							  float iminfui = 0., float iminwidth = -1., float iminfitstat = -10.,
-                              int iminntubes = 0 )
+							  int iminntubes = 0 )
 		{
 			fAxesAngles_min = iAxesAngles_min;
 			fNImages_min    = iNImages_min;

--- a/inc/VGlobalRunParameter.h
+++ b/inc/VGlobalRunParameter.h
@@ -8,6 +8,10 @@
 #include <TTree.h>
 #include <TROOT.h>
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>

--- a/inc/VImageParameter.h
+++ b/inc/VImageParameter.h
@@ -65,9 +65,7 @@ class VImageParameter
 		float length;                             //!< Length of ellipse
 		float width;                              //!< width of ellipse
 		float size;                               //!< total signal
-		float size2;                              //!< total signal (second summation window)
 		float sizeLL;                             //!< total signal; LL method
-		float size2LL;                             //!< total signal (second summation window); LL method
 		float dist;                               //!< distance to centroid
 		float azwidth;                            //!< used by certain analysis techniques
 		float alpha;                              //!< Alpha angle (-Pi/2..Pi/2)

--- a/inc/VImageParameterCalculation.h
+++ b/inc/VImageParameterCalculation.h
@@ -66,7 +66,7 @@ class VImageParameterCalculation : public TObject
 
 		VImageParameterCalculation( unsigned int iShortTree = 0, VEvndispData* iData = 0 );
 		~VImageParameterCalculation();
-		vector<bool> calcLL();                                                                 //!< calculate image parameters (log like)
+		vector<bool> calcLL(bool);                                                                 //!< calculate image parameters (log like)
 		void muonRingFinder();                                                                 //!< fit a single ring to the image to look for muons
 		void sizeInMuonRing();                                                                 //! calculate the brightness of the muon ring
 		void muonPixelDistribution();                                                          //!< determine the distribution of pixels in the image

--- a/inc/VImageParameterCalculation.h
+++ b/inc/VImageParameterCalculation.h
@@ -66,7 +66,7 @@ class VImageParameterCalculation : public TObject
 
 		VImageParameterCalculation( unsigned int iShortTree = 0, VEvndispData* iData = 0 );
 		~VImageParameterCalculation();
-		vector<bool> calcLL(bool);                                                                 //!< calculate image parameters (log like)
+		vector<bool> calcLL( bool );                                                               //!< calculate image parameters (log like)
 		void muonRingFinder();                                                                 //!< fit a single ring to the image to look for muons
 		void sizeInMuonRing();                                                                 //! calculate the brightness of the muon ring
 		void muonPixelDistribution();                                                          //!< determine the distribution of pixels in the image

--- a/inc/VImageParameterCalculation.h
+++ b/inc/VImageParameterCalculation.h
@@ -66,7 +66,7 @@ class VImageParameterCalculation : public TObject
 
 		VImageParameterCalculation( unsigned int iShortTree = 0, VEvndispData* iData = 0 );
 		~VImageParameterCalculation();
-		vector<bool> calcLL( bool iUseSums2 = false );                                         //!< calculate image parameters (log like)
+		vector<bool> calcLL();                                                                 //!< calculate image parameters (log like)
 		void muonRingFinder();                                                                 //!< fit a single ring to the image to look for muons
 		void sizeInMuonRing();                                                                 //! calculate the brightness of the muon ring
 		void muonPixelDistribution();                                                          //!< determine the distribution of pixels in the image

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -238,7 +238,6 @@ class VTableLookupDataHandler
 		double ffui       [VDST_MAXTELESCOPES];
 		double fdist_telType[VDST_MAXTELESCOPES];
 		double fsize     [VDST_MAXTELESCOPES];
-		double fsize2    [VDST_MAXTELESCOPES];
 		double fsizeCorr [VDST_MAXTELESCOPES];
 		double fsize_telType[VDST_MAXTELESCOPES];
 		double floss     [VDST_MAXTELESCOPES];
@@ -502,26 +501,8 @@ class VTableLookupDataHandler
 		{
 			return fOutFile;
 		}
-		double* getSize( double iSizeCorrection = 1., bool iSelectedImagesOnly = false, bool iSize2 = false );        // deprecated
-		double* getSize( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly, bool iSize2 = false ); // deprecated
-		double* getSize( vector<double> iSizeCorrection, bool iSelectedImagesOnly = false, bool iSize2 = false );
-		double* getSize( vector<double> iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly = false, bool iSize2 = false );
-		double* getSize2( double iSizeCorrection = 1., bool iSelectedImagesOnly = false ) // deprecated
-		{
-			return getSize( iSizeCorrection, iSelectedImagesOnly, true );
-		}
-		double* getSize2( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly ) // deprecated
-		{
-			return getSize( iSizeCorrection, iTelType, iSelectedImagesOnly, true );
-		}
-		double* getSize2( vector<double> iSizeCorrection, bool iSelectedImagesOnly )
-		{
-			return getSize( iSizeCorrection, iSelectedImagesOnly, true );
-		}
-		double* getSize2( vector<double> iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly )
-		{
-			return getSize( iSizeCorrection, iTelType, iSelectedImagesOnly, true );
-		}
+		double* getSize( double iSizeCorrection = 1., bool iSelectedImagesOnly = false );
+		double* getSize( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly);
 		double* getWeight()
 		{
 			return fweight;

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -502,7 +502,7 @@ class VTableLookupDataHandler
 			return fOutFile;
 		}
 		double* getSize( double iSizeCorrection = 1., bool iSelectedImagesOnly = false );
-		double* getSize( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly);
+		double* getSize( double iSizeCorrection, ULong64_t iTelType, bool iSelectedImagesOnly );
 		double* getWeight()
 		{
 			return fweight;

--- a/src/VCamera.cpp
+++ b/src/VCamera.cpp
@@ -903,14 +903,13 @@ void VCamera::drawEventText()
 				 fData->getImageParametersLogL()->size,
 				 fData->getImageParametersLogL()->Fitstat );
 		fTextEvent[fTextEvent.size() - 1]->SetTitle( iText );
-		sprintf( iText, "GEO: c_x=%.2f,c_y=%.2f,dist=%.2f,length=%.3f,width=%.3f,size=%.0f/%.0f,loss=%.2f,lossDead=%.2f,fui=%.2f",
+		sprintf( iText, "GEO: c_x=%.2f,c_y=%.2f,dist=%.2f,length=%.3f,width=%.3f,size=%.0f,loss=%.2f,lossDead=%.2f,fui=%.2f",
 				 fData->getImageParameters()->cen_x,
 				 fData->getImageParameters()->cen_y,
 				 fData->getImageParameters()->dist,
 				 fData->getImageParameters()->length,
 				 fData->getImageParameters()->width,
 				 fData->getImageParameters()->size,
-				 fData->getImageParameters()->size2,
 				 fData->getImageParameters()->loss,
 				 fData->getImageParameters()->lossAndDead,
 				 fData->getImageParameters()->fui );

--- a/src/VEventLoop.cpp
+++ b/src/VEventLoop.cpp
@@ -103,7 +103,11 @@ VEventLoop::VEventLoop( VEvndispRunParameter* irunparameter )
 	fCalibrator = new VCalibrator();
 
 	// create data summarizer
-	fDST = new VDST( ( fRunMode == R_DST ), ( fRunPar->fsourcetype == 1 || fRunPar->fsourcetype == 2 || fRunPar->fsourcetype == 6 ) );
+	fDST = 0;
+	if( fRunMode == R_DST )
+	{
+		fDST = new VDST( ( fRunMode == R_DST ), ( fRunPar->fsourcetype == 1 || fRunPar->fsourcetype == 2 || fRunPar->fsourcetype == 6 ) );
+	}
 
 	// create analyzer (one for all telescopes)
 	fAnalyzer = new VImageAnalyzer();

--- a/src/VGlobalRunParameter.cpp
+++ b/src/VGlobalRunParameter.cpp
@@ -178,8 +178,9 @@ bool VGlobalRunParameter::setDirectories()
 		fEVNDISPAnaDataDirectory = data_dir;
 		fEVNDISPAnaDataDirectory += "/";
 	}
-	// test if directory exists
-	if( gSystem->AccessPathName( fEVNDISPAnaDataDirectory.c_str() ) )
+	struct stat s;
+	int err = stat( fEVNDISPAnaDataDirectory.c_str(), &s );
+	if( err == -1  || !S_ISDIR( s.st_mode ) )
 	{
 		cout << "VGlobalRunParameter::setDirectories() error: cannot find directory with EVNDISP aux data" << endl;
 		cout << "\t looking for " << fEVNDISPAnaDataDirectory << endl;

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -200,7 +200,9 @@ void VImageAnalyzer::doAnalysis()
 				&& getImageParameters()->loss > fRunPar->fLogLikelihoodLoss_min[getTelID()] )
 		{
 			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
-			setLLEst( fVImageParameterCalculation->calcLL() );
+			setLLEst( fVImageParameterCalculation->calcLL( true ) );
+			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
+			setLLEst( fVImageParameterCalculation->calcLL( false ) );
 		}
 	}
 
@@ -281,7 +283,9 @@ void VImageAnalyzer::doAnalysis()
 				&& ( fRunPar->fForceLLImageFit || ( getImageParameters()->loss > fRunPar->fLogLikelihoodLoss_min[getTelID()] ) ) ) // FORCELL
 		{
 			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
-			setLLEst( fVImageParameterCalculation->calcLL() );
+			setLLEst( fVImageParameterCalculation->calcLL( true ) );
+			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
+			setLLEst( fVImageParameterCalculation->calcLL( false ) );
 		}
 
 	}
@@ -295,7 +299,9 @@ void VImageAnalyzer::doAnalysis()
 		if( getImageParameters()->ntubes > 0 )
 		{
 			fVImageParameterCalculation->setParametersLogL( getImageParametersLogL() );
-			setLLEst( fVImageParameterCalculation->calcLL() );
+			setLLEst( fVImageParameterCalculation->calcLL( true ) );
+			fVImageParameterCalculation->setParametersLogL( getImageParametersLogL() );
+			setLLEst( fVImageParameterCalculation->calcLL( false ) );
 		}
 		else
 		{

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -200,9 +200,7 @@ void VImageAnalyzer::doAnalysis()
 				&& getImageParameters()->loss > fRunPar->fLogLikelihoodLoss_min[getTelID()] )
 		{
 			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
-			setLLEst( fVImageParameterCalculation->calcLL( true ) );
-			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
-			setLLEst( fVImageParameterCalculation->calcLL( false ) );
+			setLLEst( fVImageParameterCalculation->calcLL() );
 		}
 	}
 
@@ -283,9 +281,7 @@ void VImageAnalyzer::doAnalysis()
 				&& ( fRunPar->fForceLLImageFit || ( getImageParameters()->loss > fRunPar->fLogLikelihoodLoss_min[getTelID()] ) ) ) // FORCELL
 		{
 			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
-			setLLEst( fVImageParameterCalculation->calcLL( true ) );
-			fVImageParameterCalculation->setParametersLogL( getImageParameters() );
-			setLLEst( fVImageParameterCalculation->calcLL( false ) );
+			setLLEst( fVImageParameterCalculation->calcLL() );
 		}
 
 	}
@@ -299,9 +295,7 @@ void VImageAnalyzer::doAnalysis()
 		if( getImageParameters()->ntubes > 0 )
 		{
 			fVImageParameterCalculation->setParametersLogL( getImageParametersLogL() );
-			setLLEst( fVImageParameterCalculation->calcLL( true ) );
-			fVImageParameterCalculation->setParametersLogL( getImageParametersLogL() );
-			setLLEst( fVImageParameterCalculation->calcLL( false ) );
+			setLLEst( fVImageParameterCalculation->calcLL() );
 		}
 		else
 		{

--- a/src/VImageAnalyzer.cpp
+++ b/src/VImageAnalyzer.cpp
@@ -875,10 +875,6 @@ void VImageAnalyzer::shutdown()
 	{
 		fOutputfile->Flush();
 		cout << "closing evndisp output file, final contents: ";
-		if( fReader->isMC() )
-		{
-			fOutputfile->ls();
-		}
 		cout << "\t file size: " << fOutputfile->GetSize() << endl;
 		fOutputfile->Close();
 	}

--- a/src/VImageBaseAnalyzer.cpp
+++ b/src/VImageBaseAnalyzer.cpp
@@ -1495,7 +1495,7 @@ void VImageBaseAnalyzer::calcSecondTZerosSums()
 */
 unsigned int VImageBaseAnalyzer::getDynamicSummationWindow( unsigned int i_channelHitID )
 {
-	// low gain: return larger integration window (from size2)
+	// low gain: return larger integration window
 	if( getHiLo()[i_channelHitID] )
 	{
 		return getSumWindow_2();

--- a/src/VImageParameter.cpp
+++ b/src/VImageParameter.cpp
@@ -97,12 +97,10 @@ void VImageParameter::initTree( string iName, string iTitle, bool iMC, bool iLL,
 	tpars->Branch( "length", &length, "length/F" );
 	tpars->Branch( "width", &width, "width/F" );
 	tpars->Branch( "size", &size, "size/F" );
-	tpars->Branch( "size2", &size2, "size2/F" );
 	tpars->Branch( "loss", &loss, "loss/F" );
 	if( fShortTree < 1 )
 	{
 		tpars->Branch( "sizeLL", &sizeLL, "sizeLL/F" );
-		tpars->Branch( "size2LL", &size2LL, "size2LL/F" );
 		tpars->Branch( "lossAndDead", &lossAndDead, "lossAndDead/F" );
 	}
 	tpars->Branch( "fui", &fui, "fui/F" );
@@ -277,9 +275,7 @@ void VImageParameter::reset( unsigned int resetLevel )
 	length = 0.;
 	width = 0.;
 	size = 0.;
-	size2 = 0.;
 	sizeLL = 0.;
-	size2LL = 0.;
 	loss = 0.;
 	lossAndDead = 0.;
 	fui = 0.;

--- a/src/VImageParameterCalculation.cpp
+++ b/src/VImageParameterCalculation.cpp
@@ -1149,9 +1149,7 @@ void VImageParameterCalculation::calcParameters()
 		const double dist    = sqrt( xmean2 + ymean2 );
 
 		fParGeo->size = sumsig;
-		fParGeo->size2 = sumsig_2;
 		fParGeo->sizeLL = -1.;
-		fParGeo->size2LL = -1.;
 		fParGeo->cen_x = xmean;
 		fParGeo->cen_y = ymean;
 		fParGeo->dist = dist;
@@ -1372,7 +1370,7 @@ void VImageParameterCalculation::calcParameters()
     In this case there is a large probablitity that the parameters are wrong.
 
 */
-vector<bool> VImageParameterCalculation::calcLL( bool iUseSums2 )
+vector<bool> VImageParameterCalculation::calcLL()
 {
 	if( !fData )
 	{
@@ -1441,14 +1439,7 @@ vector<bool> VImageParameterCalculation::calcLL( bool iUseSums2 )
 
 			if( fData->getImage()[j] || fData->getBorder()[j] )
 			{
-				if( iUseSums2 )
-				{
-					fll_Sums.push_back( fData->getSums2()[j] );
-				}
-				else
-				{
-					fll_Sums.push_back( fData->getSums()[j] );
-				}
+                fll_Sums.push_back( fData->getSums()[j] );
 			}
 			else
 			{
@@ -1646,10 +1637,6 @@ vector<bool> VImageParameterCalculation::calcLL( bool iUseSums2 )
 	// integrate over all bins to get fitted size
 	bool   iWidthResetted = false;
 	float  iSize = fParGeo->size;
-	if( iUseSums2 )
-	{
-		iSize = fParGeo->size2;
-	}
 	if( fParLL->Fitstat > 0 )
 	{
 		// assume that all pixel are of the same size
@@ -1733,14 +1720,7 @@ vector<bool> VImageParameterCalculation::calcLL( bool iUseSums2 )
 		cen_x  = fParGeo->cen_x;
 		cen_y  = fParGeo->cen_y;
 		phi    = fParGeo->phi;
-		if( iUseSums2 )
-		{
-			iSize  = fParGeo->size2;
-		}
-		else
-		{
-			iSize  = fParGeo->size;
-		}
+        iSize  = fParGeo->size;
 	}
 	double cosphi = cos( phi );
 	double sinphi = sin( phi );
@@ -1858,32 +1838,15 @@ vector<bool> VImageParameterCalculation::calcLL( bool iUseSums2 )
 	fParLL->cen_y = cen_y;
 	fParLL->length = length;
 	fParLL->width = width;
-	fParLL->size2LL = fParGeo->size2;
 	fParLL->sizeLL =  fParGeo->size;
-	if( iUseSums2 )
-	{
-		if( iWidthResetted )
-		{
-			fParLL->size2 = fParGeo->size2;
-		}
-		else
-		{
-			fParLL->size2 = iSize;
-		}
-		fParLL->size = fParGeo->size;
-	}
-	else
-	{
-		if( iWidthResetted )
-		{
-			fParLL->size = fParGeo->size;
-		}
-		else
-		{
-			fParLL->size = iSize;
-		}
-		fParLL->size2 = fParGeo->size2;
-	}
+    if( iWidthResetted )
+    {
+        fParLL->size = fParGeo->size;
+    }
+    else
+    {
+        fParLL->size = iSize;
+    }
 	fParLL->dist = dist;
 	fParLL->azwidth = -1.;                        // !!!!!!!!!!!!!! to tired for calculation
 	fParLL->alpha = alpha * TMath::RadToDeg();

--- a/src/VImageParameterCalculation.cpp
+++ b/src/VImageParameterCalculation.cpp
@@ -1848,7 +1848,7 @@ vector<bool> VImageParameterCalculation::calcLL()
         fParLL->size = iSize;
     }
 	fParLL->dist = dist;
-	fParLL->azwidth = -1.;                        // !!!!!!!!!!!!!! to tired for calculation
+	fParLL->azwidth = -1.;                        // !!!!!!!!!!!!!! too tired for calculation
 	fParLL->alpha = alpha * TMath::RadToDeg();
 	fParLL->los = los;
 	fParLL->miss = miss;

--- a/src/VImageParameterCalculation.cpp
+++ b/src/VImageParameterCalculation.cpp
@@ -1370,7 +1370,7 @@ void VImageParameterCalculation::calcParameters()
     In this case there is a large probablitity that the parameters are wrong.
 
 */
-vector<bool> VImageParameterCalculation::calcLL()
+vector<bool> VImageParameterCalculation::calcLL( bool iUseSums2 )
 {
 	if( !fData )
 	{
@@ -1439,7 +1439,14 @@ vector<bool> VImageParameterCalculation::calcLL()
 
 			if( fData->getImage()[j] || fData->getBorder()[j] )
 			{
-                fll_Sums.push_back( fData->getSums()[j] );
+				if( iUseSums2 )
+				{
+					fll_Sums.push_back( fData->getSums2()[j] );
+				}
+				else
+				{
+					fll_Sums.push_back( fData->getSums()[j] );
+				}
 			}
 			else
 			{
@@ -1720,7 +1727,7 @@ vector<bool> VImageParameterCalculation::calcLL()
 		cen_x  = fParGeo->cen_x;
 		cen_y  = fParGeo->cen_y;
 		phi    = fParGeo->phi;
-        iSize  = fParGeo->size;
+		iSize  = fParGeo->size;
 	}
 	double cosphi = cos( phi );
 	double sinphi = sin( phi );
@@ -1839,14 +1846,14 @@ vector<bool> VImageParameterCalculation::calcLL()
 	fParLL->length = length;
 	fParLL->width = width;
 	fParLL->sizeLL =  fParGeo->size;
-    if( iWidthResetted )
-    {
-        fParLL->size = fParGeo->size;
-    }
-    else
-    {
-        fParLL->size = iSize;
-    }
+	if( iWidthResetted )
+	{
+		fParLL->size = fParGeo->size;
+	}
+	else
+	{
+		fParLL->size = iSize;
+	}
 	fParLL->dist = dist;
 	fParLL->azwidth = -1.;                        // !!!!!!!!!!!!!! too tired for calculation
 	fParLL->alpha = alpha * TMath::RadToDeg();

--- a/src/VTableLookup.cpp
+++ b/src/VTableLookup.cpp
@@ -632,7 +632,7 @@ void VTableLookup::fillLookupTable()
 				ULong64_t t = iter_i_list_of_Tel_type->first;
 
 				// This should be already the corrected/scaled size value for MC.
-				double* i_s2 = fData->getSize2( 1., t, fTLRunParameter->fUseEvndispSelectedImagesOnly );
+				double* i_s = fData->getSize( 1., t, fTLRunParameter->fUseEvndispSelectedImagesOnly );
 				double* i_r = fData->getDistanceToCore( t );
 				unsigned int i_type = fData->getNTel_type( t );
 				////////////////////////////////////////////////
@@ -643,11 +643,11 @@ void VTableLookup::fillLookupTable()
 					for( unsigned int a = 0; a < fTableAzBins; a++ )
 					{
 						// fill tables (get arrays filled for corresponding telescope type; one table per type)
-						fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+						fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s,
 								fData->getWidth( t ), idummy1, iEventWeight, idummy3, idummy1 );
-						fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+						fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s,
 								fData->getLength( t ), idummy1, iEventWeight, idummy3, idummy1 );
-						fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+						fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s,
 								fData->getMCEnergyArray(), idummy1, iEventWeight, idummy3, idummy1 );
 					}
 				}
@@ -657,11 +657,11 @@ void VTableLookup::fillLookupTable()
 				{
 					unsigned int a = getAzBin( fData->getMCAz() );
 					// fill tables (get arrays filled for corresponding telescope type; one table per type)
-					fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+					fmscw[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s,
 							fData->getWidth( t ), idummy1, iEventWeight, idummy3, idummy1 );
-					fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+					fmscl[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s,
 							fData->getLength( t ), idummy1, iEventWeight, idummy3, idummy1 );
-					fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s2,
+					fenergySizevsRadius[0][0][w][a][i_Tel_type_counter]->calc( i_type, i_r, i_s,
 							fData->getMCEnergyArray(), idummy1, iEventWeight, idummy3, idummy1 );
 				}
 				i_Tel_type_counter++;
@@ -957,11 +957,11 @@ void VTableLookup::readLookupTable()
 			// calculate mean width ratio (mean scaled variables)
 			imr = 0.;
 			inr = 0.;
-			// require size2 > 0 (to use only selected images for the MWR/MWL calculation)
-			double* i_s2 = fData->getSize2( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly );
+			// require size > 0 (to use only selected images for the MWR/MWL calculation)
+			double* i_s = fData->getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly );
 			for( unsigned int j = 0; j < s_N->fNTel; j++ )
 			{
-				if( s_N->mscw_T[j] > 0. && fData->getWidth() && i_s2 && i_s2[j] > 0. )
+				if( s_N->mscw_T[j] > 0. && fData->getWidth() && i_s && i_s[j] > 0. )
 				{
 					imr += fData->getWidth()[j] / s_N->mscw_T[j];
 					inr++;
@@ -980,7 +980,7 @@ void VTableLookup::readLookupTable()
 			inr = 0.;
 			for( unsigned int j = 0; j < s_N->fNTel; j++ )
 			{
-				if( s_N->mscl_T[j] > 0. && fData->getLength() && i_s2 && i_s2[j] > 0. )
+				if( s_N->mscl_T[j] > 0. && fData->getLength() && i_s && i_s[j] > 0. )
 				{
 					imr += fData->getLength()[j] / s_N->mscl_T[j];
 					inr++;
@@ -1413,27 +1413,27 @@ void VTableLookup::calculateMSFromTables( VTablesToRead* s, double esys )
 	}
 	double i_dummy = 0.;
 
-	double* i_s2 = fData->getSize2( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly );
+	double* i_s = fData->getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly );
 
 	f_calc_msc->setCalculateEnergies( false );
 	///////////////////
 	// calculate mscw
 	f_calc_msc->setVHistograms( s->hmscwMedian );
 	s->mscw = f_calc_msc->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-								i_s2, fData->getWidth(),
+								i_s, fData->getWidth(),
 								s->mscw_T, i_dummy, i_dummy, s->mscw_Tsigma );
 	///////////////////
 	// calculate mscl
 	f_calc_msc->setVHistograms( s->hmsclMedian );
 	s->mscl = f_calc_msc->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-								i_s2, fData->getLength(),
+								i_s, fData->getLength(),
 								s->mscl_T, i_dummy, i_dummy, s->mscl_Tsigma );
 	///////////////////
 	// calculate energy (method 1)
 	f_calc_energySR->setCalculateEnergies( true );
 	f_calc_energySR->setVHistograms( s->henergySRMedian );
 	s->energySR = f_calc_energySR->calc( ( int )fData->getNTel(), fData->getDistanceToCore(),
-										 i_s2, 0,
+										 i_s, 0,
 										 s->energySR_T, s->energySR_Chi2, s->energySR_dE, s->energySR_Tsigma );
 }
 

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -622,7 +622,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 			getNTel(),
 			fArrayPointing_Elevation, fArrayPointing_Azimuth,
 			fTel_type,
-			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
+			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly ),
 			fcen_x, fcen_y,
 			fcosphi, fsinphi,
 			fwidth, flength,
@@ -672,7 +672,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 	i_SR.reconstruct_direction( getNTel(),
 								fArrayPointing_Elevation, fArrayPointing_Azimuth,
 								fTelX, fTelY, fTelZ,
-								getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
+								getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly ),
 								fcen_x, fcen_y,
 								fcosphi, fsinphi,
 								fwidth, flength,
@@ -707,7 +707,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 							 getNTel(),
 							 fArrayPointing_Elevation, fArrayPointing_Azimuth,
 							 fTel_type,
-							 getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
+							 getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly ),
 							 fcen_x, fcen_y,
 							 fcosphi, fsinphi,
 							 fwidth, flength,
@@ -727,7 +727,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 							getNTel(),
 							fArrayPointing_Elevation, fArrayPointing_Azimuth,
 							fTel_type,
-							getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
+							getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly ),
 							fcen_x, fcen_y,
 							fcosphi, fsinphi,
 							fwidth, flength,
@@ -753,7 +753,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 			getNTel(),
 			fArrayPointing_Elevation, fArrayPointing_Azimuth,
 			fTel_type,
-			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
+			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly ),
 			fcen_x, fcen_y,
 			fcosphi, fsinphi,
 			fwidth, flength,
@@ -832,7 +832,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 						   fArrayPointing_Elevation, fArrayPointing_Azimuth,
 						   fXoff, fYoff,
 						   fTelX, fTelY, fTelZ,
-						   getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
+						   getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly ),
 						   fcen_x, fcen_y,
 						   fcosphi, fsinphi,
 						   fwidth, flength,
@@ -2586,7 +2586,7 @@ double* VTableLookupDataHandler::getDistanceToCore( ULong64_t iTelType )
  * used for table filling only
  *
  */
-double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelectedImagesOnly)
+double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelectedImagesOnly )
 {
 	for( unsigned int i = 0; i < getNTel(); i++ )
 	{
@@ -2595,12 +2595,12 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelected
 			fsizeCorr[i] = -99.;
 			continue;
 		}
-        fsizeCorr[i] = fsize[i] * iSizeCorrection;
+		fsizeCorr[i] = fsize[i] * iSizeCorrection;
 	}
 	return fsizeCorr;
 }
 
-double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTelType, bool iSelectedImagesOnly)
+double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTelType, bool iSelectedImagesOnly )
 {
 	unsigned int z = 0;
 	for( unsigned int i = 0; i < getNTel(); i++ )
@@ -2613,7 +2613,7 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTe
 				z++;
 				continue;
 			}
-            fsize_telType[z] = fsize[i] * iSizeCorrection;
+			fsize_telType[z] = fsize[i] * iSizeCorrection;
 			z++;
 		}
 	}

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -517,7 +517,6 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 			fdist[i] = ftpars[i]->dist;
 			ffui[i] = ftpars[i]->fui;
 			fsize[i] = ftpars[i]->size;
-			fsize2[i] = ftpars[i]->size2;
 			floss[i] = ftpars[i]->loss;
 			ffracLow[i] = ftpars[i]->fracLow;
 			fwidth[i] = ftpars[i]->width;
@@ -623,7 +622,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 			getNTel(),
 			fArrayPointing_Elevation, fArrayPointing_Azimuth,
 			fTel_type,
-			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false ),
+			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
 			fcen_x, fcen_y,
 			fcosphi, fsinphi,
 			fwidth, flength,
@@ -673,7 +672,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 	i_SR.reconstruct_direction( getNTel(),
 								fArrayPointing_Elevation, fArrayPointing_Azimuth,
 								fTelX, fTelY, fTelZ,
-								getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false ),
+								getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
 								fcen_x, fcen_y,
 								fcosphi, fsinphi,
 								fwidth, flength,
@@ -708,7 +707,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 							 getNTel(),
 							 fArrayPointing_Elevation, fArrayPointing_Azimuth,
 							 fTel_type,
-							 getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false ),
+							 getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
 							 fcen_x, fcen_y,
 							 fcosphi, fsinphi,
 							 fwidth, flength,
@@ -728,7 +727,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 							getNTel(),
 							fArrayPointing_Elevation, fArrayPointing_Azimuth,
 							fTel_type,
-							getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false ),
+							getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
 							fcen_x, fcen_y,
 							fcosphi, fsinphi,
 							fwidth, flength,
@@ -754,7 +753,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 			getNTel(),
 			fArrayPointing_Elevation, fArrayPointing_Azimuth,
 			fTel_type,
-			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false ),
+			getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
 			fcen_x, fcen_y,
 			fcosphi, fsinphi,
 			fwidth, flength,
@@ -833,7 +832,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
 						   fArrayPointing_Elevation, fArrayPointing_Azimuth,
 						   fXoff, fYoff,
 						   fTelX, fTelY, fTelZ,
-						   getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false ),
+						   getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly),
 						   fcen_x, fcen_y,
 						   fcosphi, fsinphi,
 						   fwidth, flength,
@@ -1410,8 +1409,6 @@ bool VTableLookupDataHandler::setOutputFile( string iOutput, string iOption, str
 	fOTree->Branch( "dist", fdist, iTT );
 	sprintf( iTT, "size[%d]/D", fNTel );
 	fOTree->Branch( "size", fsize, iTT );
-	sprintf( iTT, "size2[%d]/D", fNTel );
-	fOTree->Branch( "size2", fsize2, iTT );
 	sprintf( iTT, "loss[%d]/D", fNTel );
 	fOTree->Branch( "loss", floss, iTT );
 	sprintf( iTT, "fracLow[%d]/D", fNTel );
@@ -2098,7 +2095,6 @@ void VTableLookupDataHandler::resetImageParameters( unsigned int i )
 	fdist[i] = 0.;
 	ffui[i] = 0.;
 	fsize[i] = 0.;
-	fsize2[i] = 0.;
 	floss[i] = 0.;
 	ffracLow[i] = 0.;
 	fwidth[i] = 0.;
@@ -2308,7 +2304,6 @@ void VTableLookupDataHandler::resetAll()
 		fdist[i] = 0.;
 		ffui[i] = 0.;
 		fsize[i] = 0.;
-		fsize2[i] = 0.;
 		fsizeCorr[i] = 0.;
 		fsize_telType[i] = 0.;
 		floss[i] = 0.;
@@ -2591,7 +2586,7 @@ double* VTableLookupDataHandler::getDistanceToCore( ULong64_t iTelType )
  * used for table filling only
  *
  */
-double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelectedImagesOnly, bool iSize2 )
+double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelectedImagesOnly)
 {
 	for( unsigned int i = 0; i < getNTel(); i++ )
 	{
@@ -2600,19 +2595,12 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection, bool iSelected
 			fsizeCorr[i] = -99.;
 			continue;
 		}
-		if( !iSize2 )
-		{
-			fsizeCorr[i] = fsize[i] * iSizeCorrection;
-		}
-		else
-		{
-			fsizeCorr[i] = fsize2[i] * iSizeCorrection;
-		}
+        fsizeCorr[i] = fsize[i] * iSizeCorrection;
 	}
 	return fsizeCorr;
 }
 
-double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTelType, bool iSelectedImagesOnly, bool iSize2 )
+double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTelType, bool iSelectedImagesOnly)
 {
 	unsigned int z = 0;
 	for( unsigned int i = 0; i < getNTel(); i++ )
@@ -2625,78 +2613,7 @@ double* VTableLookupDataHandler::getSize( double iSizeCorrection,  ULong64_t iTe
 				z++;
 				continue;
 			}
-			if( !iSize2 )
-			{
-				fsize_telType[z] = fsize[i] * iSizeCorrection;
-			}
-			else
-			{
-				fsize_telType[z] = fsize2[i] * iSizeCorrection;
-			}
-			z++;
-		}
-	}
-	return fsize_telType;
-}
-
-/*
- * get an array with image size
- *
- * called while reading lookup tables
- *
- * iSelectedImagesOnly = true: use eventdisplay selection
- *
- */
-double* VTableLookupDataHandler::getSize( vector<double> iSizeCorrection, bool iSelectedImagesOnly, bool iSize2 )
-{
-	for( unsigned int i = 0; i < getNTel(); i++ )
-	{
-		if( iSelectedImagesOnly && !fImgSel_list[i] )
-		{
-			fsizeCorr[i] = -99.;
-			continue;
-		}
-		if( !iSize2 )
-		{
-			fsizeCorr[i] = fsize[i] * iSizeCorrection[i];
-		}
-		else
-		{
-			fsizeCorr[i] = fsize2[i] * iSizeCorrection[i];
-		}
-	}
-	return fsizeCorr;
-}
-
-/*
- * get an array with image size
- *
- * called while filling lookup tables
- *
- * iSelectedImagesOnly = true: use eventdisplay selection
- *
- */
-double* VTableLookupDataHandler::getSize( vector<double> iSizeCorrection,  ULong64_t iTelType, bool iSelectedImagesOnly, bool iSize2 )
-{
-	unsigned int z = 0;
-	for( unsigned int i = 0; i < getNTel(); i++ )
-	{
-		if( fTel_type[i] == iTelType )
-		{
-			if( iSelectedImagesOnly && !fImgSel_list[i] )
-			{
-				fsize_telType[z] = -99.;
-				z++;
-				continue;
-			}
-			if( !iSize2 )
-			{
-				fsize_telType[z] = fsize[i] * iSizeCorrection[i];
-			}
-			else
-			{
-				fsize_telType[z] = fsize2[i] * iSizeCorrection[i];
-			}
+            fsize_telType[z] = fsize[i] * iSizeCorrection;
 			z++;
 		}
 	}

--- a/src/VTableLookupRunParameter.cpp
+++ b/src/VTableLookupRunParameter.cpp
@@ -299,7 +299,7 @@ bool VTableLookupRunParameter::fillParameters( int argc, char* argv[] )
 		else if( iTemp.find( "-minntubes" ) < iTemp.size() )
 		{
 			fminntubes = atoi( iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() ).c_str() );
-        }
+		}
 		else if( iTemp.find( "-minwidth" ) < iTemp.size() )
 		{
 			fminwidth = atof( iTemp.substr( iTemp.rfind( "=" ) + 1, iTemp.size() ).c_str() );


### PR DESCRIPTION
Inconsistent usage of size2 with different meanings:

- size calculated from longer integration windows (to reduce the systematic for low-gain traces)
- size from squared image calculation (which is not really implemented)
- save of size in calcLL calculation

Also noticed that calcLL is called twice due to this.

Remove size2 and consistently use size in evndisp and mscw_energy.

Fix issues in github action workflows.