### PR TITLE
v490.9-dev4 - minor fixes

### DIFF
--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -1114,7 +1114,7 @@ bool VGammaHadronCuts::applyStereoQualityCuts( unsigned int iEnergyReconstructio
 		double iErec  = getReconstructedEnergy( iEnergyReconstructionMethod );
 		double iEchi2 = getReconstructedEnergyChi2( iEnergyReconstructionMethod );
 
-		if( iErec > 0. && iEchi2 <= 0. )
+		if( iErec > 0. && iEchi2 <= fCut_EChi2_min )
 		{
 			if( bCount && fStats )
 			{

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -2768,7 +2768,7 @@ float VTableLookupDataHandler::getArrayPointingDeRotationAngle()
 */
 void VTableLookupDataHandler::fill_selected_images_after_redo_stereo_reconstruction()
 {
-	double* tmp_size = getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly, false );
+	double* tmp_size = getSize( 1., fTLRunParameter->fUseEvndispSelectedImagesOnly);
 	unsigned int ii = 0;
 	fImgSel = 0;
 	bitset<8 * sizeof( unsigned long )> i_nimage;


### PR DESCRIPTION
This includes:

- apply lower EChi2 cut in effective area calculation (usually set to zero)
- bug fix in size getter (this bug has been introduced only recently)