### PR TITLE
v491 dev2 - Adding BDTdispEnergy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,13 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.8.0
     hooks:
       - id: black
         args: ["--line-length=100"]
   # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: ["--max-line-length=100", "--extend-ignore=E203,E712"]
@@ -22,6 +22,8 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
   # gitup action
   #  - repo: https://github.com/rhysd/actionlint
   #   rev: v1.6.27
@@ -29,7 +31,7 @@ repos:
   #    - id: actionlint
   # codespell
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         args: [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
 title: "Eventdisplay: an Analysis and Reconstruction Package for VERITAS"
 # doi: 10.5281/zenodo.3559075
-version: 4.9.1
-date-released: 2023-06-15
+version: 4.91.0
+date-released: 2024-10-31
 keywords:
 - "gamma-ray astronomy"
 - "astronomy software"

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -139,6 +139,7 @@ class CData
         //[NTelPairs]
         Float_t         EmissionHeightT[VDST_MAXTELESCOPES * VDST_MAXTELESCOPES];
         Double_t        DispDiff;  // from disp method
+        Float_t         DispAbsSumWeigth;
         Float_t         Xoff_intersect;
         Float_t         Yoff_intersect;
 
@@ -236,6 +237,7 @@ class CData
         TBranch*        b_NTelPairs;              //!
         TBranch*        b_EmissionHeightT;        //!
         TBranch*        b_DispDiff; //disp
+        TBranch*        b_DispAbsSumWeigth;
         TBranch*        b_Xoff_intersect;
         TBranch*        b_Yoff_intersect;
 
@@ -801,6 +803,14 @@ void CData::Init( TTree* tree )
     {
         DispDiff = 0.;
     }
+    if( fChain->GetBranchStatus( "DispAbsSumWeigth" ) )
+    {
+        fChain->SetBranchAddress( "DispAbsSumWeigth", &DispAbsSumWeigth );
+    }
+    else
+    {
+        DispAbsSumWeigth = 0.;
+    }
     if( fChain->GetBranchStatus( "Xoff_intersect" ) )
     {
         fChain->SetBranchAddress( "Xoff_intersect", &Xoff_intersect );
@@ -966,6 +976,14 @@ Bool_t CData::Notify()
     else
     {
         b_DispDiff = 0;
+    }
+    if( fChain->GetBranchStatus( "DispAbsSumWeigth" ) )
+    {
+        b_DispAbsSumWeigth = fChain->GetBranch( "DispAbsSumWeigth" );
+    }
+    else
+    {
+        b_DispAbsSumWeigth = 0;
     }
     if( fChain->GetBranchStatus( "Xoff_intersect" ) )
     {

--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -86,21 +86,6 @@ class VDispAnalyzer
         VDispAnalyzer();
         ~VDispAnalyzer() {}
 
-        void calculateCore( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
-                            double* itelX, double* itelY, double* itelZ,
-                            ULong64_t* iTelType,
-                            double* img_size, double* img_cen_x, double* img_cen_y,
-                            double* img_cosphi, double* img_sinphi,
-                            double* img_width, double* img_length, double* img_asym,
-                            double* img_tgrad, double* img_loss, int* img_ntubes,
-                            double* img_weight,
-                            double xoff_4, double yoff_4,
-                            double* iR,
-                            double xcore, double ycore,
-                            double xs, double ys,
-                            double* img_fui,
-                            float* img_pedvar );
-
         void calculateEnergies( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
                                 ULong64_t* iTelType,
                                 double* img_size, double* img_cen_x, double* img_cen_y,
@@ -172,7 +157,6 @@ class VDispAnalyzer
         {
             return f_dispE;
         }
-        float getCoreDistance( unsigned int iTelescopeNumber );
         float getEnergy();
         float getEnergyChi2();
         float getEnergydES();

--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -51,6 +51,7 @@ class VDispAnalyzer
         vector< float > fdisp_xs_T;
         vector< float > fdisp_ys_T;
         vector< float > fdisp_xy_weight_T;
+        float fdisp_sum_abs_weigth;
         vector< float > fdisp_T;
         vector< unsigned int > fdisplist_T;
 
@@ -213,6 +214,10 @@ class VDispAnalyzer
                 return fdisp_xy_weight_T[i];
             }
             return -999.;
+        }
+        float get_abs_sum_disp_weight()
+        {
+            return fdisp_sum_abs_weigth;
         }
         bool  initialize( string iFile, string iDispMethod, string iDispType = "BDTDisp" );
         bool  isZombie()

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -317,6 +317,7 @@ class VTableLookupDataHandler
         float fYoff_T[VDST_MAXTELESCOPES];      //! direction reconstructed for each telescope
         float fWoff_T[VDST_MAXTELESCOPES];      //! direction reconstructed for each telescope (weight)
         float fDoff_T[VDST_MAXTELESCOPES];      //! (disp value)
+        float fDispAbsSumWeigth;                //! sum of absolute values of disp weights
         unsigned int fToff_T[VDST_MAXTELESCOPES]; //! list of telescope participating in disp
         unsigned int fnxyoff;                   //! number of images used for disp direction reconstruction
         // difference in disp event direction between telescopes

--- a/macros/VTS/plot_mscw_variables.C
+++ b/macros/VTS/plot_mscw_variables.C
@@ -29,6 +29,14 @@ void print_statistics_output( TH1F* h, string print_out )
         cout << " (" << h->GetEntries() << " entries)";
         cout << endl;
     }
+    else if( print_out == "VALUE" )
+    {
+        cout << "\t Value at 10 (30) TeV: ";
+        cout << h->GetBinContent( h->FindBin( log10( 10 ) ) );
+        cout << " (" << h->GetBinContent( h->FindBin( log10( 30. ) ) ) << ") ";
+        cout << " (" << h->GetEntries() << " entries)";
+        cout << endl;
+    }
 }
 
 
@@ -133,14 +141,14 @@ void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW
         V.push_back( "log10(MCe0)" );
         Vmin.push_back(-2. );
         Vmax.push_back( log10( 300. ) );
-        Vprintout.push_back( "" );
+        Vprintout.push_back( "VALUE" );
     }
     else
     {
         V.push_back( "log10(ErecS)" );
         Vmin.push_back(-2. );
         Vmax.push_back( log10( 300. ) );
-        Vprintout.push_back( "" );
+        Vprintout.push_back( "VALUE" );
     }
     if( plot_type.find( "short_mc" ) != string::npos )
     {

--- a/macros/VTS/plot_mscw_variables.C
+++ b/macros/VTS/plot_mscw_variables.C
@@ -7,6 +7,9 @@
  * print RMS or containment radii to screen
  *
  */
+
+#include <string>
+
 void print_statistics_output( TH1F* h, string print_out )
 {
     if(!h || print_out.size() == 0 )
@@ -210,6 +213,15 @@ void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW
 
         if( T2 )
         {
+            if( i >= 0 && plot_type.find("table") == string::npos )
+            {
+                size_t pos = V[i].find("ErecS");
+                if (pos != std::string::npos) {
+                    V[i].replace(pos, 5, "Erec" );
+                }
+                cout << "Energy " << i << "\t" << V[i] << endl;
+            }
+
             TList* primitives = gPad->GetListOfPrimitives();
             f2->cd();
             T2->Draw( V[i].c_str(), Vcut, "sames" );

--- a/macros/VTS/plot_mscw_variables.C
+++ b/macros/VTS/plot_mscw_variables.C
@@ -24,12 +24,12 @@ void print_statistics_output( TH1F* h, string print_out )
     }
     else if( print_out == "68p" )
     {
-        int nQuantiles = 1;
-        double value[1];
-        double prob[1] = {0.68};
+        int nQuantiles = 2;
+        double value[2];
+        double prob[2] = {0.68, 0.95};
         h->GetQuantiles( nQuantiles, value, prob );
-        cout << "\t 68% value: " << value[0];
-        cout << " (" << h->GetEntries() << " entries)";
+        cout << "\t 68% (95%) value: " << value[0] << "( " << value[1] << ", ";
+        cout << h->GetEntries() << " entries)";
         cout << endl;
     }
     else if( print_out == "VALUE" )
@@ -219,7 +219,6 @@ void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW
                 if (pos != std::string::npos) {
                     V[i].replace(pos, 5, "Erec" );
                 }
-                cout << "Energy " << i << "\t" << V[i] << endl;
             }
 
             TList* primitives = gPad->GetListOfPrimitives();

--- a/macros/VTS/plot_mscw_variables.C
+++ b/macros/VTS/plot_mscw_variables.C
@@ -179,7 +179,7 @@ void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW
     Vmax.push_back( 1.5 );
 
 
-    TCanvas* c = new TCanvas( "c", "mscw variables", 0, 100, 1600, 1100 );
+    TCanvas* c = new TCanvas( "c", "mscw variables", 0, 200, 1200, 800 );
     if( is_MC )
     {
         c->Divide( 3, 2 );

--- a/macros/VTS/plot_mscw_variables.C
+++ b/macros/VTS/plot_mscw_variables.C
@@ -49,7 +49,7 @@ void print_statistics_output( TH1F* h, string print_out )
  * - (anything else): plot large number of variables
  * - string includes 'geo': use intersection method for angular reconstruction
 */
-void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW2 = 1., string iAddCut = "ErecS>0.", string plot_type = "short_mc", string i_print_file = "" )
+void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW2 = 1., string iAddCut1 = "ErecS>0.", string iAddCut2 = "ErecS>0.", string plot_type = "short_mc", string i_print_file = "" )
 {
     TFile* f1 = new TFile( iFile1.c_str() );
     if( f1->IsZombie() )
@@ -203,7 +203,7 @@ void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW
         }
 
         char Vcut[400];
-        sprintf( Vcut, "MSCW>-2.&&MSCW<3.&&dES>0.&&%s>%f&&%s<%f&&%s", V[i].c_str(), Vmin[i], V[i].c_str(), Vmax[i], iAddCut.c_str() );
+        sprintf( Vcut, "MSCW>-2.&&MSCW<3.&&%s>%f&&%s<%f&&%s", V[i].c_str(), Vmin[i], V[i].c_str(), Vmax[i], iAddCut1.c_str() );
         cout << "Canvas " << i + 1 << ", variable " << V[i] << " cut: " << Vcut << endl;
 
         f1->cd();
@@ -220,6 +220,7 @@ void plot_mscw_variables( string iFile1, string iFile2, float iW1 = 1., float iW
                     V[i].replace(pos, 5, "Erec" );
                 }
             }
+            sprintf( Vcut, "MSCW>-2.&&MSCW<3.&&%s>%f&&%s<%f&&%s", V[i].c_str(), Vmin[i], V[i].c_str(), Vmax[i], iAddCut2.c_str() );
 
             TList* primitives = gPad->GetListOfPrimitives();
             f2->cd();

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -572,10 +572,7 @@ void VDispAnalyzer::calculateMeanDispDirection( unsigned int i_ntel,
     fdisp_sum_abs_weigth = 0.;
     for( unsigned int i = 0; i < fdisp_xy_weight_T.size(); i++ )
     {
-        if( fdisp_xy_weight_T[i] > 0. )
-        {
-            fdisp_sum_abs_weigth += fdisp_xy_weight_T[i];
-        }
+        fdisp_sum_abs_weigth += TMath::Abs(fdisp_xy_weight_T[i]);
     }
     fdisp_T = v_disp;
     fdisplist_T = v_displist;

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -800,7 +800,6 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
         if( fdisp_energy_T[i] > 0. && img_weight[i] > 0. && img_size[i] > 0. )
         {
             energy_tel.push_back( fdisp_energy_T[i] );
-            // Weighting with size may lead to a long tail towards large eres/mce0
             energy_weight.push_back( img_size[i] * img_weight[i] * img_size[i] * img_weight[i] );
             if( fDebug )
             {

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -806,9 +806,8 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
         if( fdisp_energy_T[i] > 0. && img_weight[i] > 0. && img_size[i] > 0. )
         {
             energy_tel.push_back( fdisp_energy_T[i] );
-            // Weighting with size leads to a long tail towards large eres/mce0
-            //              energy_weight.push_back( img_size[i] * img_weight[i] * img_size[i] * img_weight[i] );
-            energy_weight.push_back( img_weight[i] * img_weight[i] );
+            // Weighting with size may lead to a long tail towards large eres/mce0
+            energy_weight.push_back( img_size[i] * img_weight[i] * img_size[i] * img_weight[i] );
             if( fDebug )
             {
                 iR.push_back( iRcore[i] );

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -32,6 +32,7 @@ VDispAnalyzer::VDispAnalyzer()
     fdisp_energy_medianAbsoluteError = -9999.;
     fdisp_energy_NT = 0;
     fdisp_energyQL = -1;
+    fdisp_sum_abs_weigth = 0.;
 
     setQualityCuts();
     setDispErrorWeighting();
@@ -568,6 +569,14 @@ void VDispAnalyzer::calculateMeanDispDirection( unsigned int i_ntel,
                             tel_pointing_dx, tel_pointing_dy,
                             f_dispDiff, xoff_4, yoff_4, UseIntersectForHeadTail );
     fdisp_xy_weight_T = v_weight;
+    fdisp_sum_abs_weigth = 0.;
+    for( unsigned int i = 0; i < fdisp_xy_weight_T.size(); i++ )
+    {
+        if( fdisp_xy_weight_T[i] > 0. )
+        {
+            fdisp_sum_abs_weigth += fdisp_xy_weight_T[i];
+        }
+    }
     fdisp_T = v_disp;
     fdisplist_T = v_displist;
 }

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -760,12 +760,6 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
                                     ( float )sqrt( img_cen_x[i] * img_cen_x[i] + img_cen_y[i] * img_cen_y[i] ),
                                     ( float )img_fui[i], ( float )img_ntubes[i], ( float )img_pedvar[i] );
 
-            // dispEnergy is trained as log10(MCe0) in GeV
-            if( fdisp_energy_T[i] > -98. )
-            {
-                fdisp_energy_T[i] = TMath::Power( 10., fdisp_energy_T[i] );
-            }
-
             if( fDebug )
             {
                 cout << "VDispAnalyzer::calculateEnergies: tel " << i << " (teltype " << ( ULong64_t )iTelType[i] << ") ";

--- a/src/VTMVADispAnalyzer.cpp
+++ b/src/VTMVADispAnalyzer.cpp
@@ -104,28 +104,7 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
             bZombie = true;
             return;
         }
-        bool iSingleTelescopeAnalysis = true;
-        // try to detect if this is a single telescope analysis
-        string iLine;
-        if( i_temp_TMVAFILE.is_open() )
-        {
-            while( getline( i_temp_TMVAFILE, iLine ) )
-            {
-                if( iLine.find( "cross" ) != string::npos )
-                {
-                    iSingleTelescopeAnalysis = false;
-                    break;
-                }
-            }
-        }
-        if( iSingleTelescopeAnalysis )
-        {
-            cout << "\t single-telescope disp analysis" << endl;
-        }
-        else
-        {
-            cout << "\t multi-telescope disp analysis" << endl;
-        }
+        cout << "\t multi-telescope disp analysis" << endl;
 
         fTMVAReader[fTelescopeTypeList[i]] = new TMVA::Reader( "!Color:!Silent" );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "width", &fWidth );
@@ -135,15 +114,12 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "ntubes", &fNtubes );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "tgrad_x*tgrad_x", &fTGrad );
         // cross variable should be on this spot
-        if(!iSingleTelescopeAnalysis )
-        {
-            fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "cross", &fcross );
-        }
+        // fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "cross", &fcross );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "asym", &fAsymm );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "loss", &fLoss );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "dist", &fDist );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "fui", &fFui );
-        if( fDispType == "BDTDispEnergy" && !iSingleTelescopeAnalysis )
+        if( fDispType == "BDTDispEnergy" )
         {
             fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "EHeight", &fEHeight );
             fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "Rcore", &fRcore );

--- a/src/VTMVADispAnalyzer.cpp
+++ b/src/VTMVADispAnalyzer.cpp
@@ -113,8 +113,7 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "size", &fSize );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "ntubes", &fNtubes );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "tgrad_x*tgrad_x", &fTGrad );
-        // cross variable should be on this spot
-        // fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "cross", &fcross );
+        fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "cross", &fcross );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "asym", &fAsymm );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "loss", &fLoss );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "dist", &fDist );

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -576,8 +576,8 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
     if( fTLRunParameter->fRerunStereoReconstruction )
     {
         fill_selected_images_before_redo_stereo_reconstruction();
-        doStereoReconstruction( true );
         fmeanPedvar_Image = calculateMeanNoiseLevel( true );
+        doStereoReconstruction( true );
     }
 
     // dispEnergy

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -761,6 +761,7 @@ void VTableLookupDataHandler::doStereoReconstruction( bool bSelectedImagesOnly )
             fDoff_T[t] = fDispAnalyzerDirection->get_disp( t );
             fToff_T[t] = fDispAnalyzerDirection->get_disp_tel_list( t );
         }
+        fDispAbsSumWeigth = fDispAnalyzerDirection->get_abs_sum_disp_weight();
     }
     ////////////////////////////////////////////////////////////////////
     // Standard (intersection) method for all other cases
@@ -776,6 +777,7 @@ void VTableLookupDataHandler::doStereoReconstruction( bool bSelectedImagesOnly )
         fXoff_derot = i_SR.fShower_Xoffset;
         fYoff_derot = i_SR.fShower_Yoffset;
         fstdS = i_SR.fShower_DispDiff;
+        fDispAbsSumWeigth = 0.;
     }
 
     // overwrite the values read from the evndisp file with the newly
@@ -1440,6 +1442,7 @@ bool VTableLookupDataHandler::setOutputFile( string iOutput, string iOption, str
     fOTree->Branch( "DispXoff_T", fXoff_T, "DispXoff_T[NImages]/F" );
     fOTree->Branch( "DispYoff_T", fYoff_T, "DispYoff_T[NImages]/F" );
     fOTree->Branch( "DispWoff_T", fWoff_T, "DispWoff_T[NImages]/F" );
+    fOTree->Branch( "DispAbsSumWeigth", &fDispAbsSumWeigth, "fDispAbsSumWeigth/F" );
     fOTree->Branch( "Disp_T", fDoff_T, "Disp_T[NImages]/F" );
     fOTree->Branch( "DispTelList_T", fToff_T, "DispTelList_T[NImages]/i" );
     fOTree->Branch( "DispDiff", &fDispDiff, "DispDiff/D" );
@@ -2358,6 +2361,7 @@ void VTableLookupDataHandler::resetAll()
     fMC_distance_to_cameracenter_min = 0.;
     fMC_distance_to_cameracenter_max = 1.e10;
     fDispDiff = 0;
+    fDispAbsSumWeigth = 0.;
     fXoff_intersect = 0.;
     fYoff_intersect = 0.;
     fXoff_edisp = 0.;

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -580,11 +580,13 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
         doStereoReconstruction( true );
     }
 
-    // dispEnergy
-    // energy reconstruction using the disp MVA
-    // This is preliminary and works for MC events only!
+    // dispEnergy - energy reconstruction using the disp MVA
     if( fDispAnalyzerEnergy )
     {
+        // calculate distances and emission height
+        calcDistances();
+        calcEmissionHeights();
+
         fDispAnalyzerEnergy->setQualityCuts( fSSR_NImages_min, fSSR_AxesAngles_min,
                                              fTLRunParameter->fmaxdist,
                                              fTLRunParameter->fmaxloss,
@@ -1245,9 +1247,6 @@ bool VTableLookupDataHandler::setInputFile( vector< string > iInput )
     if( fTLRunParameter->fEnergyReconstruction_BDTFileName.size() > 0. )
     {
         cout << endl;
-        cout << "*******************************************************" << endl;
-        cout << "WARNING: dispBDT energy reconstruction not fully tested" << endl;
-        cout << "*******************************************************" << endl;
         cout << "Initializing BDT disp analyzer for energy reconstruction" << endl;
         cout << "===========================================================" << endl << endl;
         fDispAnalyzerEnergy = new VDispAnalyzer();

--- a/src/logFile.cpp
+++ b/src/logFile.cpp
@@ -35,6 +35,7 @@ void printHelp()
     cout << "\t\t tmvaLog, tmvaRunparameter" << endl;
     cout << "\t\t radAccLOG" << endl;
     cout << "\t\t effAreaLog, effAreaCuts, effAreaParameters" << endl;
+    cout << "\t\t effAreaCombineLog" << endl;
     cout << "\t to print all log files in the root file: use `printAll`" << endl;
     cout << endl;
 }

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -154,6 +154,7 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     dataloader->AddVariable( "size", 'F' );
     dataloader->AddVariable( "ntubes", 'F' );
     dataloader->AddVariable( "tgrad_x*tgrad_x", 'F' );
+    dataloader->AddVariable( "cross", 'F' );
     dataloader->AddVariable( "asym", 'F' );
     dataloader->AddVariable( "loss", 'F' );
     dataloader->AddVariable( "dist", 'F' );

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -195,7 +195,6 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     // train for energy reconstruction
     if( iTargetML.find( "DispEnergy" ) != string::npos )
     {
-        // dispEnergy is defined as log10(E)/log10(size)
         dataloader->AddTarget( "dispEnergy", 'F' );
     }
     // rotation angle
@@ -805,7 +804,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
                 dispError = sqrt(( x2 - MCxoff ) * ( x2 - MCxoff ) + ( y2 + MCyoff ) * ( y2 + MCyoff ) );
                 dispSign = -1.;
             }
-            dispEnergy = log10( i_showerpars.MCe0 );
+            dispEnergy = i_showerpars.MCe0;
             dispCore   = Rcore;
 
             if( fMapOfTrainingTree.find( fTelType[i] ) != fMapOfTrainingTree.end() )

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -801,9 +801,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
                 dispError = sqrt(( x2 - MCxoff ) * ( x2 - MCxoff ) + ( y2 + MCyoff ) * ( y2 + MCyoff ) );
                 dispSign = -1.;
             }
-
-            // training target in ratio to size
-            dispEnergy = log10( i_showerpars.MCe0 ) / log10( i_tpars[i]->size );
+            dispEnergy = log10( i_showerpars.MCe0 );
             dispCore   = Rcore;
 
             if( fMapOfTrainingTree.find( fTelType[i] ) != fMapOfTrainingTree.end() )

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -885,7 +885,7 @@ int main( int argc, char* argv[] )
     }
     // TMVA options (default options derived from hyperparameter optimisation on CTAO prod3 simulations)
     string iTMVAOptions = "NTrees=100:BoostType=Grad:Shrinkage=0.1:UseBaggedBoost:GradBaggingFraction=0.5:nCuts=20:MaxDepth=10:";
-    iMVAOptions += "PruneMethod=ExpectedError:RegressionLossFunctionBDTG=Huber:MinNodeSize=0.02:VarTransform=N";
+    iTMVAOptions += "PruneMethod=ExpectedError:RegressionLossFunctionBDTG=Huber:MinNodeSize=0.02:VarTransform=N";
     if( argc >= 9 )
     {
         iTMVAOptions = argv[8];

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -852,7 +852,7 @@ int main( int argc, char* argv[] )
         cout << "./trainTMVAforAngularReconstruction <list of input eventdisplay files (MC)> <output directory>" << endl;
         cout << "                                     <train vs test fraction> <RecID> <telescope type>" << endl;
         cout << "                                     [train for angular / energy / core reconstruction]" << endl;
-        cout << "                                     [quality cuts] [weight expression] [directory with training trees]" << endl;
+        cout << "                                     [quality cuts] [MVA options] [weight expression] [directory with training trees]" << endl;
         cout << endl;
         cout << endl;
 
@@ -872,28 +872,33 @@ int main( int argc, char* argv[] )
     unsigned int iRecID      = atoi( argv[4] );
     ULong64_t    iTelType    = atoi( argv[5] ) ;
     string       iTargetML  = "BDTDisp";
-    // TMVA options (hardwired)
-    string iTMVAOptions = "VarTransform=N:NTrees=200:BoostType=AdaBoost:MaxDepth=8";
-    string       iDataDirectory = "";
-    string iWeightExpression = "";
-    // quality cut likely overwritten from command line
-    string       iQualityCut = "size>1.&&ntubes>log10(4.)&&width>0.&&width<2.&&length>0.&&length<10.";
-    iQualityCut = iQualityCut + "&&tgrad_x<100.*100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
     if( argc >=  7 )
     {
         iTargetML = argv[6];
     }
+    // quality cut likely overwritten from command line
+    string       iQualityCut = "size>1.&&ntubes>log10(4.)&&width>0.&&width<2.&&length>0.&&length<10.";
+    iQualityCut = iQualityCut + "&&tgrad_x<100.*100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
     if( argc >=  8 )
     {
         iQualityCut = argv[7];
     }
+    // TMVA options (default options derived from hyperparameter optimisation on CTAO prod3 simulations)
+    string iTMVAOptions = "NTrees=100:BoostType=Grad:Shrinkage=0.1:UseBaggedBoost:GradBaggingFraction=0.5:nCuts=20:MaxDepth=10:";
+    iMVAOptions += "PruneMethod=ExpectedError:RegressionLossFunctionBDTG=Huber:MinNodeSize=0.02:VarTransform=N";
     if( argc >= 9 )
     {
-        iWeightExpression = argv[8];
+        iTMVAOptions = argv[8];
     }
+    string iWeightExpression = "";
     if( argc >= 10 )
     {
-        iDataDirectory = argv[9];
+        iWeightExpression = argv[9];
+    }
+    string       iDataDirectory = "";
+    if( argc >= 11 )
+    {
+        iDataDirectory = argv[10];
     }
     bool redo_stereo_reconstruction = false;
 

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -37,17 +37,31 @@
 using namespace std;
 
 /*
- * return average pointing elevation
+ * Return array pointing
+ * Note approximate implementation - assume that all triggered telescopes
+ * point in the same direction.
  *
- * NOT IMPLEMENTED - this is used for the dispEnergy reconstruction
+ * Used for the dispEnergy reconstruction
+ *
+ * first: elevation
+ * second: azimuth
  */
 pair<float, float> getArrayPointing( Cshowerpars* i_showerpars )
 {
     pair< float, float> i_mean_pointing;
-
     i_mean_pointing.first = 0.;
     i_mean_pointing.second = 0.;
-
+    if(!i_showerpars )
+    {
+        return i_mean_pointing;
+    }
+    // approximation: use first triggered telescope
+    unsigned int first_tel = ( unsigned int )i_showerpars->Trig_list[0];
+    if( first_tel < i_showerpars->NTel )
+    {
+        i_mean_pointing.first = i_showerpars->TelElevation[first_tel];
+        i_mean_pointing.second = i_showerpars->TelAzimuth[first_tel];
+    }
     return i_mean_pointing;
 }
 
@@ -594,7 +608,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
     // stereo (intersection of line) reconstruction
     // needed for the re-calculation of 'cross'
     VSimpleStereoReconstructor i_SR;
-    i_SR.initialize();
+    i_SR.initialize( 2, 10. ); // 'reasonable' starting values
 
     /////////////////////////////////////////////////
     // loop over all events in trees

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -90,7 +90,7 @@ map< ULong64_t, TTree* > fMapOfTrainingTree;
 bool trainTMVA( string iOutputDir, float iTrainTest,
                 ULong64_t iTelType, TTree* iDataTree,
                 string iTargetML, string iTMVAOptions,
-                string iQualityCut )
+                string iQualityCut, string iWeightExpression )
 {
     cout << endl;
     cout << "Starting " << iTargetML;
@@ -246,7 +246,11 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
         dataloader->AddTarget( "disp", 'F' );
     }
     // add weights (optional)
-    //    dataloader->SetWeightExpression( "MCe0*MCe0", "Regression" );
+    if( iWeightExpression.size() > 0 )
+    {
+        cout << "Weight expression (per event) applied: " << iWeightExpression << endl;
+        dataloader->SetWeightExpression( iWeightExpression.c_str(), "Regression" );
+    }
 
     // regression tree
     dataloader->AddRegressionTree( iDataTree, 1. );
@@ -849,7 +853,7 @@ int main( int argc, char* argv[] )
         cout << "./trainTMVAforAngularReconstruction <list of input eventdisplay files (MC)> <output directory>" << endl;
         cout << "                                     <train vs test fraction> <RecID> <telescope type>" << endl;
         cout << "                                     [train for angular / energy / core reconstruction]" << endl;
-        cout << "                                     [quality cuts] [directory with training trees]" << endl;
+        cout << "                                     [quality cuts] [weight expression] [directory with training trees]" << endl;
         cout << endl;
         cout << endl;
 
@@ -872,6 +876,7 @@ int main( int argc, char* argv[] )
     // TMVA options (hardwired)
     string iTMVAOptions = "VarTransform=N:NTrees=200:BoostType=AdaBoost:MaxDepth=8";
     string       iDataDirectory = "";
+    string iWeightExpression = "";
     // quality cut likely overwritten from command line
     string       iQualityCut = "size>1.&&ntubes>log10(4.)&&width>0.&&width<2.&&length>0.&&length<10.";
     iQualityCut = iQualityCut + "&&tgrad_x<100.*100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
@@ -885,7 +890,11 @@ int main( int argc, char* argv[] )
     }
     if( argc >= 9 )
     {
-        iDataDirectory = argv[8];
+        iWeightExpression = argv[8];
+    }
+    if( argc >= 10 )
+    {
+        iDataDirectory = argv[9];
     }
     bool redo_stereo_reconstruction = false;
 
@@ -977,7 +986,8 @@ int main( int argc, char* argv[] )
         trainTMVA( fOutputDir, fTrainTest,
                    fMapOfTrainingTree_iter->first,
                    fMapOfTrainingTree_iter->second,
-                   iTargetML, iTMVAOptions, iQualityCut );
+                   iTargetML, iTMVAOptions, iQualityCut,
+                   iWeightExpression );
     }
 
     //////////////////////


### PR DESCRIPTION
Adding the BDT energy reconstruction methods (which are very similar to BDT disp). The method is used since a long time for CTA analysis. This is more or less a copy of the CTA code with minor adaptions.

- added correct calculation of average array pointing for emission height calculation
- fixed issues with single telescope analysis (not relevant for VERITAS; but resulted in wrong selection of TMVA variables)
- updated code for dispEnergy reconstruction; tested (after several rounds of improvements)
