### PR TITLE
v491 dev5 - bug fixes in lookup table reading

### DIFF
--- a/inc/VTableLookup.h
+++ b/inc/VTableLookup.h
@@ -64,10 +64,10 @@ class VTableLookup
         vector< bool > fTelToAnalyze;
         vector< double > fTableZe;      // [nze]
         vector< vector< double > > fTableZeOffset;  // [nze][nwoff]
-        vector< vector< vector< vector< vector< double > > > > > fTableZeOffsetAzTelNoise;  // [nze][nwoff][naz][ntel][n
+        vector< vector< vector< vector< vector< double > > > > > fTableZeOffsetAzTelNoise;  // [nze][nwoff][naz][ntel][nnoise]
 
         // tables
-        // fmscw[ze][woff][az][tel]
+        // fmscw[ze][woff][az][tel][noise]
         vector< vector< vector< vector< ULong64_t > > > > fTelType_tables;
         vector< vector< vector< vector< vector< VTableCalculator* > > > > > fmscw;
         vector< vector< vector< vector< vector< VTableCalculator* > > > > > fmscl;

--- a/macros/VTS/optimizeBDTcuts.C
+++ b/macros/VTS/optimizeBDTcuts.C
@@ -8,7 +8,7 @@
  *
 */
 
-R__LOAD_LIBRARY($EVNDISPSYS / lib / libVAnaSum.so );
+R__LOAD_LIBRARY($EVNDISPSYS/lib/libVAnaSum.so );
 
 
 void help()

--- a/src/VPlotLookupTable.cpp
+++ b/src/VPlotLookupTable.cpp
@@ -250,7 +250,7 @@ bool VPlotLookupTable::addLookupTable( string iLookupTableFile, string iTable, i
     }
     char hname[600];
     // create full directory name
-    sprintf( hname, "NOISE_%05d/ze_%03d/woff_%04d/az_%d/tel_%d", noise, ze * 10, woff, az, telID );
+    sprintf( hname, "ze_%03d/woff_%04d/az_%d/tel_%d/NOISE_%05d", ze * 10, woff, az, telID, noise );
     if(!fI->cd( hname ) )
     {
         cout << "VPlotLookupTable::addLookupTable error: directory  " << hname << " not found" << endl;

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -461,9 +461,14 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
             fReadTPars = true;
         }
         // check if the tpars for this telescope should be read
+        // missing tpars are treated as missing telescopes
         if(!fTLRunParameter->fUseEvndispSelectedImagesOnly )
         {
             fReadTPars = true;
+            if(!ftpars[i] )
+            {
+                fReadTPars = false;
+            }
         }
         else if(( fTLRunParameter->bWriteReconstructedEventsOnly >= 0 )
                 || fTLRunParameter->bWriteReconstructedEventsOnly == -2 || fwrite )


### PR DESCRIPTION
This pull request includes several changes to the `VTableLookup` class and related files to improve the handling of noise levels, directory structure, and error checking. The most important changes include modifying the directory structure for noise levels, clearing noise-related vectors at appropriate times, and adding error checks for index boundaries.

### Directory Structure and Noise Levels:
* [`src/VPlotLookupTable.cpp`](diffhunk://#diff-b169aa876a729c59db54348848b787791371dd24acdf2c47fae51460ec0466b0L253-R253): Modified the directory structure for noise levels to place the noise directory at the end. (`[src/VPlotLookupTable.cppL253-R253](diffhunk://#diff-b169aa876a729c59db54348848b787791371dd24acdf2c47fae51460ec0466b0L253-R253)`)
* [`src/VTableLookup.cpp`](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL897-R899): Updated the directory structure format for noise levels in the `terminate` method. (`[src/VTableLookup.cppL897-R899](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL897-R899)`)

### Clearing Noise-Related Vectors:
* [`src/VTableLookup.cpp`](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fR364): Cleared noise-related vectors at appropriate times in the `setMCTableFiles` method to ensure proper memory management. (`[[1]](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fR364)`, `[[2]](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL372-R405)`, `[[3]](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL415)`)

### Error Checking:
* [`src/VTableLookup.cpp`](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL1231-R1257): Added error checks for index boundaries in the `getTables` method to prevent out-of-range errors. (`[src/VTableLookup.cppL1231-R1257](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL1231-R1257)`)

### Additional Changes:
* [`inc/VTableLookup.h`](diffhunk://#diff-af20600c21e46438b83d3280c59e76d1e5822fb93af703e3e996a3a20a6d711dL67-R70): Updated comments to reflect the inclusion of noise levels in the data structure. (`[inc/VTableLookup.hL67-R70](diffhunk://#diff-af20600c21e46438b83d3280c59e76d1e5822fb93af703e3e996a3a20a6d711dL67-R70)`)
* [`src/VTableLookup.cpp`](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fR685): Reused the `i_noise_bin` variable instead of redeclaring it in the `readLookupTable` method. (`[[1]](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fR685)`, `[[2]](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL734-R737)`, `[[3]](diffhunk://#diff-8c7714f1b69ca503cce72465a5f7b9a85d7fc8d11acc24ddffec965e2aa7e95fL758-R762)`)
* [`src/VTableLookupDataHandler.cpp`](diffhunk://#diff-0a22e38e8625ccb0dcafda3e1bc12a8a056336e20aca5b04b8593bd2ba57cfb0R464-R471): Added a check to treat missing `tpars` as missing telescopes. (`[src/VTableLookupDataHandler.cppR464-R471](diffhunk://#diff-0a22e38e8625ccb0dcafda3e1bc12a8a056336e20aca5b04b8593bd2ba57cfb0R464-R471)`)