### PR TITLE
Fix segmentation fault when exiting on error in anasum

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,6 +53,8 @@ Set the following environmental variable: `VBFSYS=<directory with VBF installati
 
 GSL libraries are used for very specific tasks (Hough muon calibration, likelihood fitter) and are not required for most users. GSL is included in all pre-compiled ROOT versions; for building from source, see the [gsl web page](http://www.gnu.org/software/gsl/).
 
+To manually switch the GSL option off, set `GSLFLAG=-DNOGSL` after the corresponding entry in the [Makefile](./Makefile) (roughly line 80).
+
 ### cfitsio (optional)
 
 FITS related output as used for the next-day analysis and requires installation of cfitsio (see http://heasarc.gsfc.nasa.gov/fitsio/).

--- a/src/VStereoAnalysis.cpp
+++ b/src/VStereoAnalysis.cpp
@@ -235,8 +235,8 @@ int VStereoAnalysis::getDataRunNumber() const
         }
         else if( fDataRun->GetEntry( 0 ) == 0 )
         {
-            cout << "VStereoAnalysis::getDataRunNumber error: tree is empty." << endl;
-            fDataRun->fChain->Print();
+            cout << "VStereoAnalysis::getDataRunNumber error: mscw data tree is empty." << endl;
+            cout << "exiting...";
         }
         else
         {
@@ -244,8 +244,9 @@ int VStereoAnalysis::getDataRunNumber() const
         }
     }
 
+    gROOT->SetMustClean(false);
     exit( EXIT_FAILURE );
-    return 0;
+    return -1;
 }
 
 


### PR DESCRIPTION
anasum was seg faulting when running on an mscw file with an empty data tree.

This merge request fixes this issue (yes, the analysis is anyway useful but tool should exit in a controlled way).