### PR TITLE
ECPL cutoff parameter corrections

### DIFF
--- a/src/VSpectralFitter.cpp
+++ b/src/VSpectralFitter.cpp
@@ -165,12 +165,12 @@ bool VSpectralFitter::defineFitFunction()
     else if( fSpectralFitFunction == 1 )
     {
         cout << "Fitfunction: power law with exponential cutoff" << endl;
-        sprintf( hname, "[0] * TMath::Power( TMath::Power( 10, x ) / %f, [1] ) * TMath::Exp( -1. * TMath::Power( 10, x ) / [2] )", fSpectralFitFluxNormalisationEnergy );
+        sprintf( hname, "[0] * TMath::Power( TMath::Power( 10, x ) / %f, [1] ) * TMath::Exp( -1. * TMath::Power( 10, x ) * [2] )", fSpectralFitFluxNormalisationEnergy );
         fFitFunction = new TF1( fFitName.c_str(), hname, log10( fSpectralFitEnergy_min ), log10( fSpectralFitEnergy_max ) );
         fFitFunction->SetParameter( 0, 1.e-7 );
         fFitFunction->SetParameter( 1, -2. );
-        fFitFunction->SetParameter( 2, 10. );
-        sprintf( hname, "[0] * TMath::Power( x  / %f, [1] ) * TMath::Exp( -1. * x / [2] )", fSpectralFitFluxNormalisationEnergy );
+        fFitFunction->SetParameter( 2, 0.1 );
+        sprintf( hname, "[0] * TMath::Power( x  / %f, [1] ) * TMath::Exp( -1. * x * [2] )", fSpectralFitFluxNormalisationEnergy );
         fFitFunction_lin = new TF1( iFitName_lin.c_str(), hname, fSpectralFitEnergy_min, fSpectralFitEnergy_max );
     }
     // broken power law fit
@@ -281,7 +281,7 @@ void VSpectralFitter::print()
         cout << "Gamma = " << fixed << setprecision( 2 ) << fFitFunction->GetParameter( 1 );
         cout << " +- " << fFitFunction->GetParError( 1 ) << endl;
         cout << "Ecut = " << fixed << setprecision( 2 ) << fFitFunction->GetParameter( 2 );
-        cout << " +- " << fFitFunction->GetParError( 2 ) << " TeV" << endl;
+        cout << " +- " << fFitFunction->GetParError( 2 ) << " TeV^-1" << endl;
         cout << "Chi2 " << setprecision( 2 ) << fFitFunction->GetChisquare();
         cout << ", N = " << fFitFunction->GetNDF();
         if( fFitFunction->GetNDF() > 0. )


### PR DESCRIPTION
Cutoff parameter for exponential cutoff power law (spectral model 1) needs to be in units of 1/TeV for correct behaviour. Previous implementation (in units of TeV) caused the fit to converge with a very steep cutoff. 