### PR TITLE
Download sofa/vbf outside of container

### DIFF
--- a/.github/workflows/ci-buildmatrix-cpp11.yml
+++ b/.github/workflows/ci-buildmatrix-cpp11.yml
@@ -48,9 +48,9 @@ jobs:
           SOFA20231011: ${{ secrets.SOFA20231011 }}
         run: |
           set -euo pipefail
-          curl -fL "https://syncandshare.desy.de/index.php/s/${VBF_TOKEN}/download" -o VBF.tar.gz
+          curl -fL --retry 3 --retry-delay 3 "https://syncandshare.desy.de/index.php/s/${VBF_TOKEN}/download" -o VBF.tar.gz
           mkdir -p sofa
-          curl -fL "https://syncandshare.desy.de/index.php/s/${SOFA20231011}/download" -o sofa/sofa.tar.gz
+          curl -fL --retry 3 --retry-delay 3 "https://syncandshare.desy.de/index.php/s/${SOFA20231011}/download" -o sofa/sofa.tar.gz
 
       - name: Build inside ROOT CentOS7 container
         run: |

--- a/.github/workflows/ci-buildmatrix-cpp11.yml
+++ b/.github/workflows/ci-buildmatrix-cpp11.yml
@@ -42,23 +42,27 @@ jobs:
       - name: Extract source
         run: tar -xzf src.tgz
 
-      - name: Build inside ROOT CentOS7 container
+      - name: Download VBF and SOFA on host
         env:
           VBF_TOKEN: ${{ secrets.VBFcpp11 }}
           SOFA20231011: ${{ secrets.SOFA20231011 }}
         run: |
           set -euo pipefail
+          curl -fL "https://syncandshare.desy.de/index.php/s/${VBF_TOKEN}/download" -o VBF.tar.gz
+          mkdir -p sofa
+          curl -fL "https://syncandshare.desy.de/index.php/s/${SOFA20231011}/download" -o sofa/sofa.tar.gz
+
+      - name: Build inside ROOT CentOS7 container
+        run: |
+          set -euo pipefail
           echo "Using ROOT image: $ROOT_IMAGE"
           docker run --rm \
-            -e VBF_TOKEN="$VBF_TOKEN" \
-            -e SOFA20231011="$SOFA20231011" \
             -v "$PWD:/workspace" \
             -w /workspace \
             "$ROOT_IMAGE" /bin/bash -c '
               set -euo pipefail
               echo "ROOT version: $(root-config --version)"
               # Build VBF
-              curl -L "https://syncandshare.desy.de/index.php/s/${VBF_TOKEN}/download" -o VBF.tar.gz
               mkdir -p VBF && tar -xzf VBF.tar.gz -C VBF --strip-components=1
               pushd VBF
               ./configure --prefix=/workspace/VBF
@@ -66,8 +70,6 @@ jobs:
               make install
               popd
               # Install SOFA
-              mkdir -p sofa
-              curl -L "https://syncandshare.desy.de/index.php/s/${SOFA20231011}/download" -o sofa/sofa.tar.gz
               ./install_sofa.sh
               # Build EventDisplay
               export EVNDISPSYS=/workspace

--- a/.github/workflows/ci-buildmatrix-cpp17.yml
+++ b/.github/workflows/ci-buildmatrix-cpp17.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: vbf
         run: |
-          curl -L https://syncandshare.desy.de/index.php/s/${{ secrets.VBFcpp17 }}/download -o VBF.tar.gz
+          curl -L --retry 3 --retry-delay 3 https://syncandshare.desy.de/index.php/s/${{ secrets.VBFcpp17 }}/download -o VBF.tar.gz
           mkdir VBF && tar -xzf VBF.tar.gz -C VBF --strip-components=1
           cd VBF && ./configure --prefix=$(echo $GITHUB_WORKSPACE)/VBF
           make
@@ -35,7 +35,7 @@ jobs:
 
       - name: sofa
         run: |
-          curl -L https://syncandshare.desy.de/index.php/s/${{ secrets.SOFA20231011 }}/download -o sofa/sofa.tar.gz
+          curl -L --retry 3 --retry-delay 3 https://syncandshare.desy.de/index.php/s/${{ secrets.SOFA20231011 }}/download -o sofa/sofa.tar.gz
           ./install_sofa.sh
 
       - name: eventdisplay


### PR DESCRIPTION
The rootproject/root:6.24.06-centos7 image is based on CentOS 7 which has an outdated CA certificate bundle. This means curl may not be able to verify the SSL certificate of syncandshare.desy.de and silently fails or follows a redirect incorrectly.