### PR TITLE
A2: fix sliding-window fRaw branch returning FADC[1] instead of charge

### DIFF
--- a/docs/changes/351.bugfix.md
+++ b/docs/changes/351.bugfix.md
@@ -1,1 +1,2 @@
 Fixes long list of bugs listed in [Issue #351](https://github.com/VERITAS-Observatory/EventDisplay_v4/issues/352).
+Fix A2: `VTraceHandler::calculateTraceSum_slidingWindow()` fRaw branch returned `FADC[1]` (second FADC sample, ped-subtracted) instead of the accumulated raw charge sum. Affected pedestal calculation path.

--- a/src/VTraceHandler.cpp
+++ b/src/VTraceHandler.cpp
@@ -771,7 +771,7 @@ double VTraceHandler::calculateTraceSum_slidingWindow( unsigned int iSearchStart
         fSumWindowFirst = n - iIntegrationWindow;
         fSumWindowLast  = n;
 
-        return FADC[1];
+        return charge;
     }
 
     ////////////////////////////////////////


### PR DESCRIPTION
calculateTraceSum_slidingWindow() fRaw branch accumulated the raw charge sum in 'charge' but returned FADC[1] (second sample, ped-subtracted) instead. Replace with 'return charge'.

Fixes A2 in issue #352.