### PR TITLE
fix(E4): guard XGB sidecar file opens by reconstruction method and cut type

### DIFF
--- a/docs/changes/352.bugfix.md
+++ b/docs/changes/352.bugfix.md
@@ -1,23 +1,5 @@
 # Bug fix: non-XGB jobs no longer probe XGB sidecar files (E4)
 
-**Files:** `src/CData.cpp`, `inc/CData.h`, `src/VStereoAnalysis.cpp`, `src/makeEffectiveArea.cpp`
-
-`CData` previously opened both the stereo-XGB and gamma-hadron-XGB friend files
-unconditionally whenever their suffix strings were non-empty, even for jobs that
-use reconstruction method 0 (DispBDT) or TMVA gamma-hadron cuts. This caused
-spurious ROOT file-open errors and hidden dependencies on XGB artifacts that are
-not required by those jobs.
-
-Changes:
-- Added `fDataFileName` private member to `CData` so the data file path is
-  available for deferred loading.
-- Added `CData::loadGHXGBTree(string gh_suffix)`: idempotent method that loads
-  the XGB gamma-hadron friend tree on demand, after the analysis type is known.
-- `VStereoAnalysis::getDataFromFile()`: stereo-XGB suffix is now only passed when
-  `fEnergyReconstructionMethod == 2` or `fDirectionReconstructionMethod == 2`;
-  GH-XGB suffix is always passed as `""` here.
-- `VStereoAnalysis::fillHistograms()`: after `setCuts()`, calls
-  `fDataRun->loadGHXGBTree()` only when `fCuts->useXGBoostCuts()` is true.
-- `makeEffectiveArea.cpp`: guards both suffixes at construction time using the
-  same conditions; `fCuts->readCuts()` is called before `CData` is constructed,
-  so the analysis type is already known.
+XGB sidecar files (stereo and gamma-hadron) are now opened only when the active
+reconstruction method and gamma-hadron cut type actually require them, eliminating
+spurious ROOT file-open errors in non-XGB jobs.

--- a/docs/changes/352.bugfix.md
+++ b/docs/changes/352.bugfix.md
@@ -1,0 +1,23 @@
+# Bug fix: non-XGB jobs no longer probe XGB sidecar files (E4)
+
+**Files:** `src/CData.cpp`, `inc/CData.h`, `src/VStereoAnalysis.cpp`, `src/makeEffectiveArea.cpp`
+
+`CData` previously opened both the stereo-XGB and gamma-hadron-XGB friend files
+unconditionally whenever their suffix strings were non-empty, even for jobs that
+use reconstruction method 0 (DispBDT) or TMVA gamma-hadron cuts. This caused
+spurious ROOT file-open errors and hidden dependencies on XGB artifacts that are
+not required by those jobs.
+
+Changes:
+- Added `fDataFileName` private member to `CData` so the data file path is
+  available for deferred loading.
+- Added `CData::loadGHXGBTree(string gh_suffix)`: idempotent method that loads
+  the XGB gamma-hadron friend tree on demand, after the analysis type is known.
+- `VStereoAnalysis::getDataFromFile()`: stereo-XGB suffix is now only passed when
+  `fEnergyReconstructionMethod == 2` or `fDirectionReconstructionMethod == 2`;
+  GH-XGB suffix is always passed as `""` here.
+- `VStereoAnalysis::fillHistograms()`: after `setCuts()`, calls
+  `fDataRun->loadGHXGBTree()` only when `fCuts->useXGBoostCuts()` is true.
+- `makeEffectiveArea.cpp`: guards both suffixes at construction time using the
+  same conditions; `fCuts->readCuts()` is called before `CData` is constructed,
+  so the analysis type is already known.

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -30,6 +30,7 @@ class CData
         vector< double > fTelX;
         vector< double > fTelY;
         vector< double > fTelZ;
+        string fDataFileName;
 
         void reconstruct_3tel_images( long unsigned int );
         void reconstruct_3tel_images_direction();
@@ -280,6 +281,7 @@ class CData
         float get_Yoff( unsigned int method );
         void   initialize_xgb_tree();
         TTree* getXGBTree( string file_name, string suffix, string tree_name );
+        bool   loadGHXGBTree( string gh_suffix );
         pair<float, float> get_XYoff_derot( unsigned int method );
         virtual Long64_t LoadTree( Long64_t entry );
         float            get_GH_Gamma_Prediction();

--- a/src/CData.cpp
+++ b/src/CData.cpp
@@ -31,6 +31,7 @@ CData::CData( TTree* tree, bool bMC, bool bShort, string file_name, string stere
     fShort = bShort;
     fVersion = 6;
     fTelescopeCombination = 0;
+    fDataFileName = file_name;
     Init( tree );
 
     fStereoFriendTree = getXGBTree( file_name, stereo_suffix, "StereoAnalysis" );
@@ -1125,4 +1126,26 @@ void CData::initialize_xgb_tree()
         GH_Gamma_Prediction = -9999.;
         GH_Is_Gamma = false;
     }
+}
+
+/*
+ * Deferred loading of the XGB gamma-hadron friend tree.
+ * Call this after the analysis type is known (e.g. after readCuts()),
+ * when the caller has confirmed that XGB gamma-hadron cuts are active.
+ * Idempotent: a second call is a no-op if the tree is already loaded.
+ */
+bool CData::loadGHXGBTree( string gh_suffix )
+{
+    if( fGHFriendTree )
+    {
+        return true;
+    }
+    if( fDataFileName.empty() )
+    {
+        cout << "CData::loadGHXGBTree error: no data file name stored" << endl;
+        return false;
+    }
+    fGHFriendTree = getXGBTree( fDataFileName, gh_suffix, "Classification" );
+    initialize_xgb_tree();
+    return ( fGHFriendTree != 0 );
 }

--- a/src/VStereoAnalysis.cpp
+++ b/src/VStereoAnalysis.cpp
@@ -348,6 +348,14 @@ double VStereoAnalysis::fillHistograms( int icounter, int irun, double iAzMin, d
     // initialize cuts
     setCuts( fRunPara->fRunList[fHisCounter], irun );
 
+    // load XGB gamma-hadron friend tree now that the analysis type is known
+    if( fCuts && fCuts->useXGBoostCuts()
+            && fDataRun
+            && !fRunPara->fXGB_gh_file_suffix.empty() )
+    {
+        fDataRun->loadGHXGBTree( fRunPara->fXGB_gh_file_suffix );
+    }
+
     // define histograms
     fDirTotRun[fHisCounter]->cd();
     fHisto[fHisCounter]->setRunNumber( irun );
@@ -1967,8 +1975,9 @@ CData* VStereoAnalysis::getDataFromFile( int i_runNumber )
             false,
             false,
             iFileName,
-            fRunPara->fXGB_stereo_file_suffix,
-            fRunPara->fXGB_gh_file_suffix
+            ( fRunPara->fEnergyReconstructionMethod == 2 || fRunPara->fDirectionReconstructionMethod == 2 )
+                ? fRunPara->fXGB_stereo_file_suffix : "",
+            ""  // GH XGB tree loaded later, after analysis type is known from cut file
         );
         // read current (major) epoch from data file
         VEvndispRunParameter* i_runPara = ( VEvndispRunParameter* )fDataFile->Get( "runparameterV2" );

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -180,7 +180,11 @@ int main( int argc, char* argv[] )
         exit( EXIT_FAILURE );
     }
 
-    CData d( c, true, false, fRunPara->fdatafile, fRunPara->fXGB_stereo_file_suffix, fRunPara->fXGB_gh_file_suffix );
+    const bool i_need_stereo_xgb = ( fRunPara->fEnergyReconstructionMethod == 2
+                                        || fRunPara->fDirectionReconstructionMethod == 2 );
+    CData d( c, true, false, fRunPara->fdatafile,
+             i_need_stereo_xgb ? fRunPara->fXGB_stereo_file_suffix : "",
+             fCuts->useXGBoostCuts() ? fRunPara->fXGB_gh_file_suffix : "" );
     d.initialize_3tel_reconstruction(
         fRunPara->fRerunStereoReconstruction_3telescopes,
         fRunPara->fRerunStereoReconstruction_minAngle,


### PR DESCRIPTION
Fixes issue #352 item E4: non-XGB jobs were unconditionally opening both XGB sidecar files causing spurious ROOT file-open errors and hidden artifact dependencies.

Changes:
- CData: store filename; add idempotent loadGHXGBTree()
- VStereoAnalysis::getDataFromFile(): guard stereo suffix; skip GH at construction
- VStereoAnalysis::fillHistograms(): defer GH loading until after setCuts()
- makeEffectiveArea.cpp: guard both suffixes at construction (cut type already known)