### PR TITLE
fix: explicit NegWeightTreatment=Pray for BoostType=Grad in TMVA angular training

### DIFF
--- a/docs/changes/353.bugfix.md
+++ b/docs/changes/353.bugfix.md
@@ -1,0 +1,7 @@
+# Bug fix: explicit NegWeightTreatment for TMVA Gradient BDT angular reconstruction
+
+Added `NegWeightTreatment=Pray` to the default TMVA options in
+`trainTMVAforAngularReconstruction` to match actual TMVA behaviour:
+`BoostType=Grad` does not support `InverseBoostNegWeights` (TMVA's global
+default) and silently replaces it with `Pray`; the options string now
+declares this explicitly so the training configuration matches what is used.

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -878,8 +878,10 @@ int main( int argc, char* argv[] )
         iQualityCut = argv[7];
     }
     // TMVA options (default options derived from hyperparameter optimisation on CTAO prod3 simulations)
+    // NegWeightTreatment=Pray is explicit here: BoostType=Grad does not support
+    // InverseBoostNegWeights (TMVA's global default) and silently replaces it with Pray.
     string iTMVAOptions = "NTrees=100:BoostType=Grad:Shrinkage=0.1:UseBaggedBoost:GradBaggingFraction=0.5:nCuts=20:MaxDepth=10:";
-    iTMVAOptions += "PruneMethod=ExpectedError:RegressionLossFunctionBDTG=Huber:MinNodeSize=0.02:VarTransform=N";
+    iTMVAOptions += "PruneMethod=ExpectedError:RegressionLossFunctionBDTG=Huber:MinNodeSize=0.02:NegWeightTreatment=Pray:VarTransform=N";
     if( argc >= 9 )
     {
         iTMVAOptions = argv[8];


### PR DESCRIPTION
BoostType=Grad does not support InverseBoostNegWeights (TMVA BDT global default), causing a silent replacement with Pray and a mismatch between nominal and effective training configuration. Adds the explicit option to the default string.