### PR TITLE
v492.0 dev22

### DIFF
--- a/docs/changes/366.bugfix.md
+++ b/docs/changes/366.bugfix.md
@@ -1,0 +1,1 @@
+Fix branch name of 95% containment radius in IRFs (name included 80).

--- a/docs/changes/366.feature.md
+++ b/docs/changes/366.feature.md
@@ -1,0 +1,1 @@
+Improve data / MC comparison for directional variables.

--- a/inc/VDataMCComparision.h
+++ b/inc/VDataMCComparision.h
@@ -118,7 +118,7 @@ class VDataMCComparision
         // angle for shower max correction
         double fShowerMaxZe_deg;
 
-        // optional preselection in theta squared; a non-positive value disables it
+        // optional override for theta2 preselection; values >= 0 override defaults (0 disables the cut)
         double fTheta2Cut;
 
         void setEntries( TH1D* );

--- a/inc/VDataMCComparision.h
+++ b/inc/VDataMCComparision.h
@@ -118,6 +118,9 @@ class VDataMCComparision
         // angle for shower max correction
         double fShowerMaxZe_deg;
 
+        // optional preselection in theta squared; a non-positive value disables it
+        double fTheta2Cut;
+
         void setEntries( TH1D* );
         void setEntries( TH2D* );
 
@@ -148,6 +151,10 @@ class VDataMCComparision
         void setShowerMaximZe_deg( double iZe = 20. )
         {
             fShowerMaxZe_deg = iZe;
+        }
+        void setTheta2Cut( double iTheta2Cut = -1. )
+        {
+            fTheta2Cut = iTheta2Cut;
         }
         void   setStereoReconstructionMethod( unsigned int iEnergyMethod = 0, unsigned int iDirectionMethod = 0 )
         {

--- a/inc/VEffectiveAreaCalculator.h
+++ b/inc/VEffectiveAreaCalculator.h
@@ -252,7 +252,7 @@ class VEffectiveAreaCalculator
         float Rec_effNoTh2_error[1000];
 
         float Rec_angRes_p68[1000];
-        float Rec_angRes_p80[1000];
+        float Rec_angRes_p95[1000];
 
         // H2F effective area tree
         float fH2F_e0_esys[1000];

--- a/src/VDataMCComparision.cpp
+++ b/src/VDataMCComparision.cpp
@@ -290,6 +290,7 @@ VDataMCComparision::VDataMCComparision( string iname, int intel )
     fWobbleFromDataTree = false;
 
     setShowerMaximZe_deg();
+    setTheta2Cut();
 
     defineHistograms();
 }
@@ -626,15 +627,20 @@ bool VDataMCComparision::fillHistograms( string ifile, int iSingleTelescopeCuts 
     double fCoreMax_QC = 350;        // cut on core distance
     int    fNImages_min = 2;         // minimum number of images per event
     // stereo cuts
-    double theta2_cut = 0.035; // 0.35;
+    double theta2_cut = 0.035;
     if( iSingleTelescopeCuts > 0 || iSingleTelescopeCuts == -2 )
     {
         theta2_cut = 0.2;
     }
     if( iSingleTelescopeCuts == -3 )
     {
-        theta2_cut = 0.035; //0.035;
+        theta2_cut = 0.035;
     }
+    if( fTheta2Cut >= 0. )
+    {
+        theta2_cut = fTheta2Cut;
+    }
+    bool applyTheta2Cut = theta2_cut > 0.;
 
     double theta2_min = 0.;
     double msw_max = 2.0;
@@ -727,7 +733,7 @@ bool VDataMCComparision::fillHistograms( string ifile, int iSingleTelescopeCuts 
     {
         cout << " stereo cuts (hardwired)" << endl;
         cout << "\t " << msw_min << " < MSCW < " << msw_max << ", " << msl_min << " < MSCL < " << msl_max;
-        cout << ", theta2 < " << theta2_cut << " deg2" << endl;
+        cout << endl;
     }
     else if( fSingleTelescopeCuts == -2 )
     {
@@ -735,7 +741,14 @@ bool VDataMCComparision::fillHistograms( string ifile, int iSingleTelescopeCuts 
     }
     else if( fSingleTelescopeCuts == -3 )
     {
-        cout << " Theta2 cut (<" << theta2_cut << " deg2),  ";
+        if( applyTheta2Cut )
+        {
+            cout << " Theta2 cut (<" << theta2_cut << " deg2),  ";
+        }
+        else
+        {
+            cout << " no theta2 cut,  ";
+        }
         cout << " Size2ndMax cut (>" << size2ndmax_min << ")" << endl;
     }
     else
@@ -930,7 +943,7 @@ bool VDataMCComparision::fillHistograms( string ifile, int iSingleTelescopeCuts 
         /////////////////////////////////////////////////////////
         //   ---    apply theta2 cuts ---
         /////////////////////////////////////////////////////////
-        if( fSingleTelescopeCuts < -1 )
+        if( fSingleTelescopeCuts == -3 && applyTheta2Cut )
         {
             if( theta2 <= theta2_min || theta2 > theta2_cut )
             {
@@ -953,7 +966,7 @@ bool VDataMCComparision::fillHistograms( string ifile, int iSingleTelescopeCuts 
                 continue;
             }
             // wobble cut
-            if( fWobbleNorth != 0. || fWobbleEast != 0. )
+            if( ( fWobbleNorth != 0. || fWobbleEast != 0. ) && applyTheta2Cut )
             {
                 if( theta2 <= theta2_min || theta2 > theta2_cut )
                 {

--- a/src/VEffectiveAreaCalculator.cpp
+++ b/src/VEffectiveAreaCalculator.cpp
@@ -392,7 +392,7 @@ VEffectiveAreaCalculator::VEffectiveAreaCalculator( VInstrumentResponseFunctionR
     fEffArea->Branch( "Rec_seff_U", Rec_seff_U, "Rec_seff_U[Rec_nbins]/D" );
 
     fEffArea->Branch( "Rec_angRes_p68", Rec_angRes_p68, "Rec_angRes_p68[Rec_nbins]/F" );
-    fEffArea->Branch( "Rec_angRes_p80", Rec_angRes_p80, "Rec_angRes_p80[Rec_nbins]/F" );
+    fEffArea->Branch( "Rec_angRes_p95", Rec_angRes_p95, "Rec_angRes_p95[Rec_nbins]/F" );
 
     // For reconstructing the response matrices
     fEffArea->Branch( "nbins_ResMat", &nbins_ResMat, "nbins_ResMat/I" );
@@ -1131,7 +1131,7 @@ void VEffectiveAreaCalculator::multiplyByScatterArea( TGraphAsymmErrors* g )
 */
 void VEffectiveAreaCalculator::fillAngularResolution( unsigned int i_az, bool iContainment_95p )
 {
-    if( iContainment_95p && i_az < fGraph_AngularResolution68p.size() && fGraph_AngularResolution68p[i_az] )
+    if( iContainment_95p && i_az < fGraph_AngularResolution95p.size() && fGraph_AngularResolution95p[i_az] )
     {
         // get first and last energy bin
         double i_emin = 1.e5;
@@ -1154,7 +1154,7 @@ void VEffectiveAreaCalculator::fillAngularResolution( unsigned int i_az, bool iC
         {
             if( Rec_e0[i] > i_emin && Rec_e0[i] < i_emax )
             {
-                Rec_angRes_p80[i]  = fGraph_AngularResolution95p[i_az]->Eval( Rec_e0[i] );
+                Rec_angRes_p95[i]  = fGraph_AngularResolution95p[i_az]->Eval( Rec_e0[i] );
             }
         }
     }
@@ -1900,7 +1900,7 @@ void VEffectiveAreaCalculator::reset()
         ResMat_Rec[i] = 0.;
         ResMat_Rec_Err[i] = 0.;
         Rec_angRes_p68[i] = 0.;
-        Rec_angRes_p80[i] = 0.;
+        Rec_angRes_p95[i] = 0.;
 
     }
 
@@ -2533,7 +2533,7 @@ bool VEffectiveAreaCalculator::fill( TH1D* hE0mc, CData* d,
                 Rec_eff_error[i] = 0.;
                 Rec_effNoTh2_error[i] = 0.;
                 Rec_angRes_p68[i] = 0.;
-                Rec_angRes_p80[i] = 0.;
+                Rec_angRes_p95[i] = 0.;
             }
             double x = 0.;
             double y = 0.;

--- a/src/combineEffectiveAreas.cpp
+++ b/src/combineEffectiveAreas.cpp
@@ -373,7 +373,7 @@ void merge( vector< string > file_list,
     {
         f.SetBranchStatus( "Rec_effNoTh2", 1 );
         f.SetBranchStatus( "Rec_angRes_p68", 1 );
-        f.SetBranchStatus( "Rec_angRes_p80", 1 );
+        f.SetBranchStatus( "Rec_angRes_p95", 1 );
         // Full histograms for DL3
         f.SetBranchStatus( "hEsysMCRelative2D", 1 );
         f.SetBranchStatus( "hEsysMCRelative2DNoDirectionCut", 1 );

--- a/src/compareDatawithMC.cpp
+++ b/src/compareDatawithMC.cpp
@@ -210,11 +210,13 @@ int main( int argc, char* argv[] )
         cout << endl;
         cout << "compareDatawithMC <input file list> <cut> <outputfile> ";
         cout << "[BDT gamma/hadron cuts] [epoch_ATM] [stereo reconstruction method] ";
-        cout << "[XGB stereo file suffix] [shower max zenith angle (default=20deg)]" << endl;
+        cout << "[XGB stereo file suffix] [shower max zenith angle (default=20deg)] ";
+        cout << "[theta2 cut in deg2; <=0 disables it]" << endl;
         cout << endl;
         cout << "\t input file list: see example file COMPAREMC.runparameter in the parameter files directory" << endl;
         cout << "\t cuts: " << endl;
-        cout << "\t\t cut=-3:        theta2 cut only (RECOMMENDED CUT)" << endl;
+        cout << "\t\t cut=-3:        theta2 cut only (default: theta2 < 0.035 deg2)" << endl;
+        cout << "\t\t                  use the optional theta2-cut argument <= 0 for no theta2 preselection" << endl;
         cout << "\t\t in most cases, the following cuts should not be used: " << endl;
         cout << "\t\t cut=-2:        no cuts" << endl;
         cout << "\t\t cut=-1:        stereo cuts (MSCW, etc.)" << endl;
@@ -267,11 +269,33 @@ int main( int argc, char* argv[] )
     {
         fXGBStereoFileSuffix = argv[7];
     }
+    double fShowerMaxZe_deg = 20.;
+    if( argc > 8 )
+    {
+        fShowerMaxZe_deg = atof( argv[8] );
+    }
+    double fTheta2Cut = -1.;
+    if( argc > 9 )
+    {
+        fTheta2Cut = atof( argv[9] );
+    }
     cout << "Stereo reconstruction methods for energy: " << fEnergyReconstructionMethod;
     cout << ", direction: " << fDirectionReconstructionMethod << endl;
     if( fEnergyReconstructionMethod == 2 || fDirectionReconstructionMethod == 2 )
     {
         cout << "XGB stereo file suffix: " << fXGBStereoFileSuffix << endl;
+    }
+    cout << "Shower maximum zenith angle: " << fShowerMaxZe_deg << " deg" << endl;
+    if( fTheta2Cut >= 0. )
+    {
+        if( fTheta2Cut > 0. )
+        {
+            cout << "Theta2 cut: " << fTheta2Cut << " deg2" << endl;
+        }
+        else
+        {
+            cout << "Theta2 cut: disabled" << endl;
+        }
     }
 
 
@@ -338,6 +362,8 @@ int main( int argc, char* argv[] )
         fStereoCompare.push_back( new VDataMCComparision( fInputData[i].fType, fInputData[i].fNTelescopes ) );
         fStereoCompare.back()->setStereoReconstructionMethod( fEnergyReconstructionMethod, fDirectionReconstructionMethod );
         fStereoCompare.back()->setXGBStereoFileSuffix( fXGBStereoFileSuffix );
+        fStereoCompare.back()->setShowerMaximZe_deg( fShowerMaxZe_deg );
+        fStereoCompare.back()->setTheta2Cut( fTheta2Cut );
         if( fCalculateMVACut )
         {
             fStereoCompare.back()->setTMVABDTComparision( fEpochATM );

--- a/src/compareDatawithMC.cpp
+++ b/src/compareDatawithMC.cpp
@@ -211,7 +211,7 @@ int main( int argc, char* argv[] )
         cout << "compareDatawithMC <input file list> <cut> <outputfile> ";
         cout << "[BDT gamma/hadron cuts] [epoch_ATM] [energy reconstruction method] ";
         cout << "[XGB stereo file suffix] [shower max zenith angle (default=20deg)] ";
-        cout << "[theta2 cut in deg2; <=0 disables it] [direction reconstruction method]" << endl;
+        cout << "[theta2 cut in deg2; <=0: use default] [direction reconstruction method]" << endl;
         cout << endl;
         cout << "\t input file list: see example file COMPAREMC.runparameter in the parameter files directory" << endl;
         cout << "\t cuts: " << endl;

--- a/src/compareDatawithMC.cpp
+++ b/src/compareDatawithMC.cpp
@@ -209,9 +209,9 @@ int main( int argc, char* argv[] )
         cout << endl;
         cout << endl;
         cout << "compareDatawithMC <input file list> <cut> <outputfile> ";
-        cout << "[BDT gamma/hadron cuts] [epoch_ATM] [stereo reconstruction method] ";
+        cout << "[BDT gamma/hadron cuts] [epoch_ATM] [energy reconstruction method] ";
         cout << "[XGB stereo file suffix] [shower max zenith angle (default=20deg)] ";
-        cout << "[theta2 cut in deg2; <=0 disables it]" << endl;
+        cout << "[theta2 cut in deg2; <=0 disables it] [direction reconstruction method]" << endl;
         cout << endl;
         cout << "\t input file list: see example file COMPAREMC.runparameter in the parameter files directory" << endl;
         cout << "\t cuts: " << endl;
@@ -228,7 +228,8 @@ int main( int argc, char* argv[] )
         cout << "\t use BDT cuts for gamma/hadron separation: 0 = no (default), 1 = yes" << endl;
         cout << "\t cut file needs to be indicated within VDataMCComparision::initialGammaHadronCuts()" << endl;
         cout << endl;
-        cout << "\t stereo reconstruction method: 0 = default, 2 = XGB stereo" << endl;
+        cout << "\t reconstruction methods: 0 = default, 2 = XGB stereo" << endl;
+        cout << "\t direction reconstruction method: optional final argument; defaults to the energy method" << endl;
         cout << "\t XGB stereo file suffix: defaults to xgb_stereo for method 2" << endl;
         cout << endl;
         cout << "Note: most cuts are hardwired in VDataMCComparision::fillHistograms()" << endl;
@@ -278,6 +279,15 @@ int main( int argc, char* argv[] )
     if( argc > 9 )
     {
         fTheta2Cut = atof( argv[9] );
+    }
+    if( argc > 10 )
+    {
+        fDirectionReconstructionMethod = atoi( argv[10] );
+    }
+    if( fXGBStereoFileSuffix.empty()
+            && ( fEnergyReconstructionMethod == 2 || fDirectionReconstructionMethod == 2 ) )
+    {
+        fXGBStereoFileSuffix = "xgb_stereo";
     }
     cout << "Stereo reconstruction methods for energy: " << fEnergyReconstructionMethod;
     cout << ", direction: " << fDirectionReconstructionMethod << endl;
@@ -330,6 +340,8 @@ int main( int argc, char* argv[] )
         if( fInputData[i].fType == "ON" )
         {
             VDataMCComparision iTemp( fInputData[i].fType, fInputData[i].fNTelescopes );
+            iTemp.setStereoReconstructionMethod( fEnergyReconstructionMethod, fDirectionReconstructionMethod );
+            iTemp.setXGBStereoFileSuffix( fXGBStereoFileSuffix );
             iTemp.setAzRange( fInputData[i].fAz_deg_min, fInputData[i].fAz_deg_max );
             iTemp.setZeRange( fInputData[i].fZe_deg_min, fInputData[i].fZe_deg_max );
             hAzOn = iTemp.getAzimuthWeightingHistogram( fInputData[i].fFileName );

--- a/src/compareDatawithMC.cpp
+++ b/src/compareDatawithMC.cpp
@@ -216,7 +216,7 @@ int main( int argc, char* argv[] )
         cout << "\t input file list: see example file COMPAREMC.runparameter in the parameter files directory" << endl;
         cout << "\t cuts: " << endl;
         cout << "\t\t cut=-3:        theta2 cut only (default: theta2 < 0.035 deg2)" << endl;
-        cout << "\t\t                  use the optional theta2-cut argument <= 0 for no theta2 preselection" << endl;
+        cout << "\t\t                  use the optional theta2-cut argument 0 for no theta2 preselection" << endl;
         cout << "\t\t in most cases, the following cuts should not be used: " << endl;
         cout << "\t\t cut=-2:        no cuts" << endl;
         cout << "\t\t cut=-1:        stereo cuts (MSCW, etc.)" << endl;

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -143,7 +143,7 @@ int main( int argc, char* argv[] )
         f_IRF_Name.push_back( "angular_resolution" );
         f_IRF_Type.push_back( "angular_resolution" );
         f_IRF_ContainmentProbability.push_back( 0.68 );
-        // 80% angular resolution file
+        // 95% angular resolution file
         f_IRF_Name.push_back( "angular_resolution_095p" );
         f_IRF_Type.push_back( "angular_resolution" );
         f_IRF_ContainmentProbability.push_back( 0.95 );


### PR DESCRIPTION
This pull request introduces two main sets of changes: (1) improvements to the flexibility and configurability of the `theta2` (theta squared) cut in the data/MC comparison workflow, and (2) updates to the angular resolution output to use the 95% containment value instead of 80%. These changes affect both the C++ classes and the command-line interface, allowing users to specify the `theta2` cut as an optional argument and disabling it if desired. The angular resolution output and related variables are now consistently using the 95% containment value.

**Enhancements to theta2 cut configuration:**

* Added a new member variable `fTheta2Cut` and corresponding setter `setTheta2Cut` to `VDataMCComparision`, allowing the `theta2` cut to be specified externally and optionally disabled [[1]](diffhunk://#diff-cee7a33a4558fa99be8eb60d58a8c651166d5678f85abac6e8b69d5df00df2daR121-R123) [[2]](diffhunk://#diff-cee7a33a4558fa99be8eb60d58a8c651166d5678f85abac6e8b69d5df00df2daR155-R158).
* Updated the command-line interface in `compareDatawithMC.cpp` to accept `theta2` cut as an optional argument, with help text and logic to handle default and disabled states [[1]](diffhunk://#diff-8d67121ae7d4405eae6b672247c2fba4201362f22914c15f519a583916cf8152L212-R219) [[2]](diffhunk://#diff-8d67121ae7d4405eae6b672247c2fba4201362f22914c15f519a583916cf8152R273-R309).
* Modified `fillHistograms` to use the new `fTheta2Cut` value, including logic to disable the cut if a non-positive value is set, and improved user output to reflect whether the cut is applied [[1]](diffhunk://#diff-5dcceeea50a95a463f2f04d38d1921fbdfa9112c210368a0e5976d45bca92b3dL629-R643) [[2]](diffhunk://#diff-5dcceeea50a95a463f2f04d38d1921fbdfa9112c210368a0e5976d45bca92b3dL730-R751) [[3]](diffhunk://#diff-5dcceeea50a95a463f2f04d38d1921fbdfa9112c210368a0e5976d45bca92b3dL933-R946) [[4]](diffhunk://#diff-5dcceeea50a95a463f2f04d38d1921fbdfa9112c210368a0e5976d45bca92b3dL956-R969).

**Angular resolution output update:**

* Changed all code and data structures to use the 95% containment value (`Rec_angRes_p95`) instead of the previous 80% (`Rec_angRes_p80`), including variable names, ROOT branches, and logic in `VEffectiveAreaCalculator` and related merging/combining code [[1]](diffhunk://#diff-7f749880c00ace2913080a9abbe011787912b469be1383013d38a03a5e1c06e9L255-R255) [[2]](diffhunk://#diff-10ea36e17ce2cad1bb17e8e6c962589dbc7c2f58cdac3adf7c29754e16e980b8L395-R395) [[3]](diffhunk://#diff-10ea36e17ce2cad1bb17e8e6c962589dbc7c2f58cdac3adf7c29754e16e980b8L1134-R1134) [[4]](diffhunk://#diff-10ea36e17ce2cad1bb17e8e6c962589dbc7c2f58cdac3adf7c29754e16e980b8L1157-R1157) [[5]](diffhunk://#diff-10ea36e17ce2cad1bb17e8e6c962589dbc7c2f58cdac3adf7c29754e16e980b8L1903-R1903) [[6]](diffhunk://#diff-10ea36e17ce2cad1bb17e8e6c962589dbc7c2f58cdac3adf7c29754e16e980b8L2536-R2536) [[7]](diffhunk://#diff-235d17aa25b98a209bbbb255d7a8a4d44413a87cf00a9c93ea4ae7e681743810L376-R376) [[8]](diffhunk://#diff-01e4d6219a52956cf9ac8daebfc3bb730a36a2a3539b815ffae15fb6d73fe6d3L146-R146).

**Command-line and workflow improvements:**

* Updated help text and argument parsing in `compareDatawithMC.cpp` to clarify the use of energy/direction reconstruction methods and the new optional arguments [[1]](diffhunk://#diff-8d67121ae7d4405eae6b672247c2fba4201362f22914c15f519a583916cf8152L212-R219) [[2]](diffhunk://#diff-8d67121ae7d4405eae6b672247c2fba4201362f22914c15f519a583916cf8152L229-R232).
* Ensured that all relevant arguments (shower max zenith angle, theta2 cut, reconstruction methods) are passed down to `VDataMCComparision` instances [[1]](diffhunk://#diff-8d67121ae7d4405eae6b672247c2fba4201362f22914c15f519a583916cf8152R343-R344) [[2]](diffhunk://#diff-8d67121ae7d4405eae6b672247c2fba4201362f22914c15f519a583916cf8152R377-R378) [[3]](diffhunk://#diff-5dcceeea50a95a463f2f04d38d1921fbdfa9112c210368a0e5976d45bca92b3dR293).

These changes collectively make the analysis workflow more flexible and bring the angular resolution reporting in line with standard practices.